### PR TITLE
PR-01 feat/add AuthContext with session listener and currentUser state

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "../db/supabase";
+
+const AuthContext = createContext();
+
+export const useAuth = () => {
+  return useContext(AuthContext);
+};
+
+export const AuthProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null);
+  const [session, setSession] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+  supabase.auth.getSession().then(({ data: { session } }) => {
+    setSession(session);
+    setCurrentUser(session?.user ?? null);
+    setLoading(false);
+  });
+
+  const { data: { subscription } } = supabase.auth.onAuthStateChange(
+    (_event, session) => {
+      setSession(session);
+      setCurrentUser(session?.user ?? null);
+      setLoading(false);
+    }
+  );
+
+  return () => subscription.unsubscribe();
+}, []);
+
+return (
+    <AuthContext.Provider value={{ currentUser, session, loading }}>
+      {!loading && children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { AuthProvider } from './context/AuthContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## **What this PR does**
- Created `src/context/AuthContext.jsx` with session listener and currentUser state
- Created `src/db/supabase.js` as the Supabase client connector
- Wrapped `<App />` with `<AuthProvider>` in `main.jsx`

## **Changes Made**
- AuthContext provides `currentUser`, `session`, and `loading` state to the entire app
- `supabase.auth.getSession()` checks for existing session on app load
- `supabase.auth.onAuthStateChange()` listens for login/logout events
- `useAuth()` custom hook exported for easy access across components