### PR TITLE
PR-10 fix/auth pipeline, blank screen, and post-login routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,53 +1,50 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { supabase } from './db/supabase';
+import { useAuth } from './context/AuthContext'; // ✅ Consume context instead of Supabase directly
 
 import ProtectedRoute from './router/ProtectedRoute';
 import AuthPage from './pages/AuthPage';
-import AuthCallback from './pages/AuthCallBack';
+import AuthCallBack from './pages/AuthCallBack'; // ✅ Using the Vercel-safe capitalized name!
 import MainLayout from './components/MainLayout';
 
 /* ── placeholder pages (replace with real ones later) ── */
-const Dashboard = () => (
+const ProductsPage = () => (
   <div>
-    <h1 className="text-xl font-bold text-[#31511E] mb-1">Dashboard</h1>
-    <p className="text-xs text-[#859F3D]">Welcome to Hope PMS.</p>
+    <h1 className="text-xl font-bold text-[#31511E] mb-1">Products</h1>
+    <p className="text-xs text-[#859F3D]">Welcome to Hope PMS Products.</p>
   </div>
 );
 
 function App() {
-  const [session, setSession] = useState(undefined); // undefined = loading
-
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => setSession(session));
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, s) => setSession(s));
-    return () => subscription.unsubscribe();
-  }, []);
+  // ✅ Bug #6 Fixed: Consume global auth state instead of running a duplicate listener
+  const { session, loading } = useAuth();
 
   // While checking auth state, show nothing (or a spinner)
-  if (session === undefined) return null;
+  if (loading) return null;
 
   return (
     <BrowserRouter>
       <Routes>
         {/* public */}
         <Route path="/login" element={<AuthPage />} />
-        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route path="/auth/callback" element={<AuthCallBack />} />
 
         {/* protected */}
         <Route
-          path="/dashboard"
+          path="/products"
           element={
-            <ProtectedRoute session={session}>
-              <MainLayout user={session?.user}>
-                <Dashboard />
+            // ✅ Bug #7 Fixed: Removed 'session={session}' prop. 
+            // ProtectedRoute will read directly from AuthContext now.
+            <ProtectedRoute>
+              {/* Removed user={session?.user} prop. MainLayout should also use useAuth() internally! */}
+              <MainLayout>
+                <ProductsPage />
               </MainLayout>
             </ProtectedRoute>
           }
         />
 
         {/* fallback */}
-        <Route path="*" element={<Navigate to={session ? '/dashboard' : '/login'} replace />} />
+        <Route path="*" element={<Navigate to={session ? '/products' : '/login'} replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { useAuth } from './context/AuthContext'; // ✅ Consume context instead of Supabase directly
+import { useAuth } from './context/AuthContext'; 
 
 import ProtectedRoute from './router/ProtectedRoute';
 import AuthPage from './pages/AuthPage';
@@ -14,37 +14,100 @@ const ProductsPage = () => (
   </div>
 );
 
-function App() {
-  // ✅ Bug #6 Fixed: Consume global auth state instead of running a duplicate listener
-  const { session, loading } = useAuth();
+const ReportsPage = () => (
+  <div>
+    <h1 className="text-xl font-bold text-[#31511E] mb-1">Reports</h1>
+    <p className="text-xs text-[#859F3D]">View system reports here.</p>
+  </div>
+);
 
-  // While checking auth state, show nothing (or a spinner)
+const AdminPage = () => (
+  <div>
+    <h1 className="text-xl font-bold text-[#31511E] mb-1">Admin Dashboard</h1>
+    <p className="text-xs text-[#859F3D]">Manage users and system settings.</p>
+  </div>
+);
+
+const DeletedItemsPage = () => (
+  <div>
+    <h1 className="text-xl font-bold text-[#31511E] mb-1">Deleted Items</h1>
+    <p className="text-xs text-[#859F3D]">Recover or permanently delete items.</p>
+  </div>
+);
+
+function App() {
+  // ✅ Consuming currentUser instead of session for more accurate routing logic
+  const { currentUser, loading } = useAuth();
+
+  // Show nothing while auth state is being determined
   if (loading) return null;
 
   return (
     <BrowserRouter>
       <Routes>
-        {/* public */}
+        {/* Public */}
         <Route path="/login" element={<AuthPage />} />
         <Route path="/auth/callback" element={<AuthCallBack />} />
 
-        {/* protected */}
-        <Route
-          path="/products"
+        {/* Protected */}
+        <Route 
+          path="/products" 
           element={
-            // ✅ Bug #7 Fixed: Removed 'session={session}' prop. 
-            // ProtectedRoute will read directly from AuthContext now.
             <ProtectedRoute>
-              {/* Removed user={session?.user} prop. MainLayout should also use useAuth() internally! */}
-              <MainLayout>
+              {/* Passing currentUser back to MainLayout */}
+              <MainLayout user={currentUser}>
                 <ProductsPage />
               </MainLayout>
             </ProtectedRoute>
-          }
+          } 
+        />
+        
+        <Route 
+          path="/reports" 
+          element={
+            <ProtectedRoute>
+              <MainLayout user={currentUser}>
+                <ReportsPage />
+              </MainLayout>
+            </ProtectedRoute>
+          } 
+        />
+        
+        <Route 
+          path="/admin" 
+          element={
+            <ProtectedRoute>
+              <MainLayout user={currentUser}>
+                <AdminPage />
+              </MainLayout>
+            </ProtectedRoute>
+          } 
+        />
+        
+        <Route 
+          path="/deleted-items" 
+          element={
+            <ProtectedRoute>
+              <MainLayout user={currentUser}>
+                <DeletedItemsPage />
+              </MainLayout>
+            </ProtectedRoute>
+          } 
         />
 
-        {/* fallback */}
-        <Route path="*" element={<Navigate to={session ? '/products' : '/login'} replace />} />
+        {/* Root and fallback — explicit redirect based on auth state */}
+        <Route 
+          path="/" 
+          element={
+            <Navigate to={currentUser ? '/products' : '/login'} replace />
+          } 
+        />
+        <Route 
+          path="*" 
+          element={
+            <Navigate to={currentUser ? '/products' : '/login'} replace />
+          } 
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -13,24 +13,48 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-  supabase.auth.getSession().then(({ data: { session } }) => {
-    setSession(session);
-    setCurrentUser(session?.user ?? null);
-    setLoading(false);
-  });
+    // ✅ Bug #5 Fixed: Helper function to fetch and merge custom user data
+    const fetchAndMergeUser = async (currentSession) => {
+      if (!currentSession?.user) {
+        setCurrentUser(null);
+        return;
+      }
 
-  const { data: { subscription } } = supabase.auth.onAuthStateChange(
-    (_event, session) => {
+      const { data: userRow, error } = await supabase
+        .from('user')
+        .select('userid, username, firstName, lastName, user_type, record_status')
+        .eq('userid', currentSession.user.id)
+        .single();
+
+      if (error) {
+        console.error("Error fetching custom user details:", error);
+        setCurrentUser(currentSession.user); // Fallback to just the auth object
+      } else {
+        // Spread both objects together into one powerful currentUser
+        setCurrentUser({ ...currentSession.user, ...userRow });
+      }
+    };
+
+    // 1. Check the initial session on page load
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
-      setCurrentUser(session?.user ?? null);
+      await fetchAndMergeUser(session);
       setLoading(false);
-    }
-  );
+    });
 
-  return () => subscription.unsubscribe();
-}, []);
+    // 2. Listen for active login/logout events
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (_event, session) => {
+        setSession(session);
+        await fetchAndMergeUser(session);
+        setLoading(false);
+      }
+    );
 
-return (
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return (
     <AuthContext.Provider value={{ currentUser, session, loading }}>
       {!loading && children}
     </AuthContext.Provider>

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -22,7 +22,7 @@ export const AuthProvider = ({ children }) => {
 
       const { data: userRow, error } = await supabase
         .from('user')
-        .select('userid, username, firstName, lastName, user_type, record_status')
+        .select('userid, username, firstname, lastname, user_type, record_status')
         .eq('userid', currentSession.user.id)
         .single();
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -13,41 +13,45 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // ✅ Bug #5 Fixed: Helper function to fetch and merge custom user data
     const fetchAndMergeUser = async (currentSession) => {
       if (!currentSession?.user) {
         setCurrentUser(null);
+        setLoading(false); // ✅ Always resolve loading even with no session
         return;
       }
 
-      const { data: userRow, error } = await supabase
-        .from('user')
-        .select('userid, username, firstname, lastname, user_type, record_status')
-        .eq('userid', currentSession.user.id)
-        .single();
+      try {
+        const { data: userRow, error } = await supabase
+          .from('user')
+          .select('userid, username, firstname, lastname, user_type, record_status')
+          .eq('userid', currentSession.user.id)
+          .single();
 
-      if (error) {
-        console.error("Error fetching custom user details:", error);
-        setCurrentUser(currentSession.user); // Fallback to just the auth object
-      } else {
-        // Spread both objects together into one powerful currentUser
-        setCurrentUser({ ...currentSession.user, ...userRow });
+        if (error || !userRow) {
+          console.error("Error fetching user row:", error);
+          setCurrentUser(currentSession.user); // Fallback to auth object
+        } else {
+          setCurrentUser({ ...currentSession.user, ...userRow });
+        }
+      } catch (err) {
+        console.error("fetchAndMergeUser threw:", err);
+        setCurrentUser(currentSession.user); // Never leave user stranded
+      } finally {
+        setLoading(false); // ✅ ALWAYS fires — app never stays blank
       }
     };
 
-    // 1. Check the initial session on page load
-    supabase.auth.getSession().then(async ({ data: { session } }) => {
+    // 1. Check initial session on page load
+    supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
-      await fetchAndMergeUser(session);
-      setLoading(false);
+      fetchAndMergeUser(session);
     });
 
-    // 2. Listen for active login/logout events
+    // 2. Listen for login/logout events
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (_event, session) => {
+      (_event, session) => {
         setSession(session);
-        await fetchAndMergeUser(session);
-        setLoading(false);
+        fetchAndMergeUser(session);
       }
     );
 
@@ -56,7 +60,7 @@ export const AuthProvider = ({ children }) => {
 
   return (
     <AuthContext.Provider value={{ currentUser, session, loading }}>
-      {!loading && children}
+      {children} {/* ✅ Always renders — loading state handled in App.jsx */}
     </AuthContext.Provider>
   );
 };

--- a/src/pages/AuthCallBack.jsx
+++ b/src/pages/AuthCallBack.jsx
@@ -7,51 +7,56 @@ import { supabase } from '../db/supabase';
  * Handles the redirect after OAuth (e.g. Google Sign-In).
  * Place this at route: /auth/callback
  */
-export default function AuthCallback() {
+export default function AuthCallBack() {
   const navigate = useNavigate();
 
   useEffect(() => {
     // Supabase automatically parses the URL hash on page load.
     // We just wait for the session to be established, then redirect.
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, session) => 
-  {
-      if (event === 'SIGNED_IN' && session) 
-    {
-    // Check record_status before allowing access
-    const { data, error } = await supabase
-      .from('user')
-      .select('record_status')
-      .eq('userId', session.user.id)
-      .single();
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        // Check record_status before allowing access
+        const { data, error } = await supabase
+          .from('user')
+          .select('record_status')
+          .eq('userid', session.user.id)
+          .single();
 
-    if (error || !data || data.record_status !== 'ACTIVE') 
-      {
-      await supabase.auth.signOut();
-      navigate('/login?error=inactive', { replace: true });
-      } else {
-      navigate('/dashboard', { replace: true });
+        if (error || !data || data.record_status !== 'ACTIVE') {
+          await supabase.auth.signOut();
+          navigate('/login?error=inactive', { replace: true });
+        } else {
+          // Bug #3 Fixed: Route to /products instead of /dashboard
+          navigate('/products', { replace: true });
+        }
       }
-    }
-  });
+    });
 
     // Fallback: check current session in case the event already fired
     supabase.auth.getSession().then(async ({ data: { session } }) => {
-  if (session) {
-    const { data, error } = await supabase
-      .from('user')
-      .select('record_status')
-      .eq('userId', session.user.id)
-      .single();
+      if (session) {
+        const { data, error } = await supabase
+          .from('user')
+          .select('record_status')
+          .eq('userid', session.user.id)
+          .single();
 
-    if (error || !data || data.record_status !== 'ACTIVE') {
-      await supabase.auth.signOut();
-      navigate('/login?error=inactive', { replace: true });
-    } else {
-      navigate('/dashboard', { replace: true });
-    }
-  }
-});
+        if (error || !data || data.record_status !== 'ACTIVE') {
+          await supabase.auth.signOut();
+          navigate('/login?error=inactive', { replace: true });
+        } else {
+          // Bug #3 Fixed: Route to /products instead of /dashboard
+          navigate('/products', { replace: true });
+        }
+      }
+    });
 
+    // Bug #2 Fixed: Proper cleanup function to prevent memory leaks
+    return () => subscription.unsubscribe();
+    
+  }, [navigate]); // Bug #2 Fixed: Added dependency array
+
+  // Bug #1 Fixed: JSX is now safely outside the useEffect block
   return (
     <div className="min-h-screen flex items-center justify-center bg-[#eeeeee8f]"
       style={{ backgroundImage: 'radial-gradient(circle at 50% 50%, #859F3D12 0%, transparent 60%)' }}>
@@ -99,4 +104,3 @@ export default function AuthCallback() {
     </div>
   );
 }
-  );}

--- a/src/router/ProtectedRoute.jsx
+++ b/src/router/ProtectedRoute.jsx
@@ -1,30 +1,24 @@
 import { Navigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
 import { supabase } from '../db/supabase';
 
-const ProtectedRoute = ({ children, session }) => {
-  const [status, setStatus] = useState('checking');
+const ProtectedRoute = ({ children }) => {
+  // ✅ Read directly from our global context
+  const { currentUser, loading } = useAuth();
 
-  useEffect(() => {
-    if (!session) { setStatus('no-session'); return; }
+  // Wait for the context to finish fetching
+  if (loading) return null;
 
-    supabase
-      .from('user')
-      .select('record_status')
-      .eq('id', session.user.id)
-      .single()
-      .then(({ data, error }) => {
-        if (error || !data) { setStatus('inactive'); return; }
-        setStatus(data.record_status === 'ACTIVE' ? 'active' : 'inactive');
-      });
-  }, [session]);
+  // No user logged in? Send to login.
+  if (!currentUser) return <Navigate to="/login" replace />;
 
-  if (status === 'checking') return null;
-  if (status === 'no-session') return <Navigate to="/login" replace />;
-  if (status === 'inactive') {
+  // User is logged in, but their account isn't activated yet? Kick them out.
+  if (currentUser.record_status !== 'ACTIVE') {
     supabase.auth.signOut();
     return <Navigate to="/login?error=inactive" replace />;
   }
+
+  // If they pass all checks, render the page!
   return children;
 };
 


### PR DESCRIPTION
## What Changed
This PR resolves all critical Sprint 1 auth issues discovered during 
integration testing. Covers AuthContext, ProtectedRoute, AuthCallback, 
and App.jsx routing.

---

## Why It Was Needed
After merging the initial auth implementation, end-to-end testing 
revealed the following failures:
- App rendered a blank white screen on load
- Manual login triggered "account pending approval" for ACTIVE users
- Google OAuth redirected to a non-existent /dashboard route
- ProtectedRoute never found the user row due to wrong column name
- AuthContext loading state never resolved if the DB query failed

---

## Changes Per File

### `AuthContext.jsx`
- Wrapped `fetchAndMergeUser` in `try/catch/finally` to guarantee
  `setLoading(false)` always fires regardless of DB query outcome
- Added `setLoading(false)` to the no-session path to prevent
  permanent blank screen on logged-out state
- Fixed column query from `firstName/lastName` → `firstname/lastname`
  to match actual public.user schema
- Removed `{!loading && children}` gate from AuthProvider — loading
  is now handled exclusively in App.jsx via `if (loading) return null`

### `ProtectedRoute.jsx`
- Refactored to consume `useAuth()` directly instead of accepting
  `session` as a prop
- Now reads `record_status` from the merged `currentUser` object
  provided by AuthContext — no redundant DB query

### `AuthCallback.jsx`
- Fixed JSX `return` moved outside `useEffect` (was causing crash)
- Fixed `navigate('/dashboard')` → `navigate('/products')`
- Added `return () => subscription.unsubscribe()` cleanup
- Added `[navigate]` dependency array to useEffect
- Added login guard with `record_status` check on both
  `onAuthStateChange` and `getSession()` fallback paths

### `App.jsx`
- Removed duplicate `supabase.auth` session listener
- Replaced `/dashboard` placeholder with correct `/products` route
- Added all required protected routes: `/products`, `/reports`,
  `/admin`, `/deleted-items`
- Added explicit `/` root route with auth-based redirect
- Fixed `*` fallback to use `currentUser` from `useAuth()`
- Passed `currentUser` from context to `MainLayout` user prop

### Supabase Dashboard (Configuration)
- Added `http://localhost:5173/auth/callback` to Redirect URLs
- Added `https://hope-pms-product-management-system.vercel.app` 
  to Redirect URLs
- Added `https://hope-pms-product-management-system.vercel.app/auth/callback`
  to Redirect URLs
