### PR TITLE
PR-05 feat/rights-context UserRightsContext + useRights hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import ProtectedRoute from './router/ProtectedRoute';
 import AuthPage from './pages/AuthPage';
 import AuthCallBack from './pages/AuthCallBack'; 
 import MainLayout from './components/MainLayout';
+import RightsDebugger from './test/RightsDebugger';
 
 /* ── placeholder pages ── */
 const ProductsPage = () => (
@@ -38,7 +39,7 @@ const DeletedItemsPage = () => (
 
 function App() {
   const { currentUser, loading } = useAuth();
-  const { canAccessAdmin, canViewDeleted } = useRights(); // ✅ Pull permissions from context
+  const { canAccessAdmin, canViewDeleted, rightsLoading } = useRights(); // ✅ Pull permissions from context
 
   // Show nothing while auth state is being determined
   if (loading) return null;
@@ -73,28 +74,29 @@ function App() {
           } 
         />
         
-        {/* ✅ Admin Gating */}
-        <Route 
-          path="/admin" 
-          element={
-            <ProtectedRoute>
-              {canAccessAdmin ? (
-                <MainLayout user={currentUser}>
-                  <AdminPage />
-                </MainLayout>
-              ) : (
-                <Navigate to="/products" replace />
-              )}
-            </ProtectedRoute>
-          } 
-        />
         
-        {/* ✅ Deleted Items Gating */}
-        <Route 
-          path="/deleted-items" 
+      {/* ✅ Admin Gating */}
+      <Route
+        path="/admin"
+        element={
+          <ProtectedRoute>
+            {rightsLoading ? null : canAccessAdmin ? (
+              <MainLayout user={currentUser}>
+                <AdminPage />
+              </MainLayout>
+            ) : (
+              <Navigate to="/products" replace />
+            )}
+          </ProtectedRoute>
+        }
+      />
+
+      {/* ✅ Deleted Items Gating */}
+      <Route
+          path="/deleted-items"
           element={
             <ProtectedRoute>
-              {canViewDeleted ? (
+              {rightsLoading ? null : canViewDeleted ? (
                 <MainLayout user={currentUser}>
                   <DeletedItemsPage />
                 </MainLayout>
@@ -102,7 +104,7 @@ function App() {
                 <Navigate to="/products" replace />
               )}
             </ProtectedRoute>
-          } 
+          }
         />
 
         {/* Root and fallback */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,13 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './context/AuthContext'; 
+import { useRights } from './context/UserRightsContext'; // ✅ Added for PR-05
 
 import ProtectedRoute from './router/ProtectedRoute';
 import AuthPage from './pages/AuthPage';
-import AuthCallBack from './pages/AuthCallBack'; // ✅ Using the Vercel-safe capitalized name!
+import AuthCallBack from './pages/AuthCallBack'; 
 import MainLayout from './components/MainLayout';
 
-/* ── placeholder pages (replace with real ones later) ── */
+/* ── placeholder pages ── */
 const ProductsPage = () => (
   <div>
     <h1 className="text-xl font-bold text-[#31511E] mb-1">Products</h1>
@@ -36,8 +37,8 @@ const DeletedItemsPage = () => (
 );
 
 function App() {
-  // ✅ Consuming currentUser instead of session for more accurate routing logic
   const { currentUser, loading } = useAuth();
+  const { canAccessAdmin, canViewDeleted } = useRights(); // ✅ Pull permissions from context
 
   // Show nothing while auth state is being determined
   if (loading) return null;
@@ -54,7 +55,6 @@ function App() {
           path="/products" 
           element={
             <ProtectedRoute>
-              {/* Passing currentUser back to MainLayout */}
               <MainLayout user={currentUser}>
                 <ProductsPage />
               </MainLayout>
@@ -73,29 +73,39 @@ function App() {
           } 
         />
         
+        {/* ✅ Admin Gating */}
         <Route 
           path="/admin" 
           element={
             <ProtectedRoute>
-              <MainLayout user={currentUser}>
-                <AdminPage />
-              </MainLayout>
+              {canAccessAdmin ? (
+                <MainLayout user={currentUser}>
+                  <AdminPage />
+                </MainLayout>
+              ) : (
+                <Navigate to="/products" replace />
+              )}
             </ProtectedRoute>
           } 
         />
         
+        {/* ✅ Deleted Items Gating */}
         <Route 
           path="/deleted-items" 
           element={
             <ProtectedRoute>
-              <MainLayout user={currentUser}>
-                <DeletedItemsPage />
-              </MainLayout>
+              {canViewDeleted ? (
+                <MainLayout user={currentUser}>
+                  <DeletedItemsPage />
+                </MainLayout>
+              ) : (
+                <Navigate to="/products" replace />
+              )}
             </ProtectedRoute>
           } 
         />
 
-        {/* Root and fallback — explicit redirect based on auth state */}
+        {/* Root and fallback */}
         <Route 
           path="/" 
           element={

--- a/src/context/UserRightsContext.jsx
+++ b/src/context/UserRightsContext.jsx
@@ -1,45 +1,82 @@
-import { createContext, useContext, useMemo } from "react";
+// src/context/UserRightsContext.jsx
+import { createContext, useContext, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
+import { supabase } from "../db/supabase";
 
-// 1. Initialize the Context
-const UserRightsContext = createContext();
+const UserRightsContext = createContext(null);
 
-// 2. Custom Hook for easy access in components
 export const useRights = () => {
   const context = useContext(UserRightsContext);
-  if (!context) {
-    throw new Error("useRights must be used within a UserRightsProvider");
-  }
+  if (!context) throw new Error("useRights must be used within a UserRightsProvider");
   return context;
 };
 
 export const UserRightsProvider = ({ children }) => {
-  const { currentUser } = useAuth(); // Consume AuthContext
+  const { currentUser } = useAuth();
+  const [rights, setRights] = useState({});
+  const [rightsLoading, setRightsLoading] = useState(true);
 
-  // 3. Define the Permissions Logic
-  // We use useMemo so we only recalculate when the currentUser changes
-  const rights = useMemo(() => {
-    const role = currentUser?.user_type;
+  useEffect(() => {
+    // No user logged in — clear rights and stop loading
+    if (!currentUser?.userid) {
+      setRights({});
+      setRightsLoading(false);
+      return;
+    }
 
-    return {
-      // Role Checks
-      isAdmin: role === 'Admin',
-      isStaff: role === 'Staff',
-      isViewer: role === 'Viewer',
+    const fetchRights = async () => {
+      setRightsLoading(true);
+      try {
+        const { data, error } = await supabase
+          .from('user_module_rights')
+          .select('right_id, rights_value')
+          .eq('userid', currentUser.userid)
+          .eq('record_status', 'ACTIVE');
 
-      // Feature Gating (PR-06 & PR-07)
-      canEdit: ['Admin', 'Staff'].includes(role),
-      canDelete: role === 'Admin',
-      canAccessAdmin: role === 'Admin',
-      canViewDeleted: role === 'Admin',
-      
-      // Helper for UI loading states
-      hasRightsLoaded: !!currentUser
+        if (error) throw error;
+
+        // Build rights map from DB rows
+        // Result: { PRD_ADD: 1, PRD_EDIT: 1, PRD_DEL: 0, REP_001: 1, REP_002: 0, ADM_USER: 0 }
+        const rightsMap = {};
+        data.forEach(row => {
+          rightsMap[row.right_id] = row.rights_value;
+        });
+
+        setRights(rightsMap);
+      } catch (err) {
+        console.error("Failed to fetch user rights:", err);
+        setRights({});
+      } finally {
+        setRightsLoading(false);
+      }
     };
-  }, [currentUser]);
+
+    fetchRights();
+  }, [currentUser?.userid]); // Re-fetch only when the logged-in user changes
+
+  // ── Derived role values ───────────────────────────────────
+  const userType = currentUser?.user_type ?? 'USER';
+
+  const value = {
+    // Raw rights map from DB — used by M2 for button gating
+    // Usage: rights.PRD_ADD === 1, rights.PRD_DEL === 1
+    rights,
+    rightsLoading,
+
+    // Role identity checks
+    userType,
+    isUser:       userType === 'USER',
+    isAdmin:      userType === 'ADMIN',
+    isSuperAdmin: userType === 'SUPERADMIN',
+
+    // ── Convenience flags for App.jsx route gating ──────────
+    // Both ADMIN and SUPERADMIN can access these routes
+    canAccessAdmin:  ['ADMIN', 'SUPERADMIN'].includes(userType),
+    canViewDeleted:  ['ADMIN', 'SUPERADMIN'].includes(userType),
+  };
 
   return (
-    <UserRightsContext.Provider value={rights}>
+    <UserRightsContext.Provider value={value}>
       {children}
     </UserRightsContext.Provider>
   );

--- a/src/context/UserRightsContext.jsx
+++ b/src/context/UserRightsContext.jsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useMemo } from "react";
+import { useAuth } from "./AuthContext";
+
+// 1. Initialize the Context
+const UserRightsContext = createContext();
+
+// 2. Custom Hook for easy access in components
+export const useRights = () => {
+  const context = useContext(UserRightsContext);
+  if (!context) {
+    throw new Error("useRights must be used within a UserRightsProvider");
+  }
+  return context;
+};
+
+export const UserRightsProvider = ({ children }) => {
+  const { currentUser } = useAuth(); // Consume AuthContext
+
+  // 3. Define the Permissions Logic
+  // We use useMemo so we only recalculate when the currentUser changes
+  const rights = useMemo(() => {
+    const role = currentUser?.user_type;
+
+    return {
+      // Role Checks
+      isAdmin: role === 'Admin',
+      isStaff: role === 'Staff',
+      isViewer: role === 'Viewer',
+
+      // Feature Gating (PR-06 & PR-07)
+      canEdit: ['Admin', 'Staff'].includes(role),
+      canDelete: role === 'Admin',
+      canAccessAdmin: role === 'Admin',
+      canViewDeleted: role === 'Admin',
+      
+      // Helper for UI loading states
+      hasRightsLoaded: !!currentUser
+    };
+  }, [currentUser]);
+
+  return (
+    <UserRightsContext.Provider value={rights}>
+      {children}
+    </UserRightsContext.Provider>
+  );
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,15 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { AuthProvider } from './context/AuthContext'
+import { UserRightsProvider } from './context/UserRightsContext' // Import the new provider
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      {/* UserRightsProvider must be a child of AuthProvider to use its context */}
+      <UserRightsProvider>
+        <App />
+      </UserRightsProvider>
     </AuthProvider>
   </StrictMode>,
 )

--- a/src/router/ProtectedRoute.jsx
+++ b/src/router/ProtectedRoute.jsx
@@ -3,35 +3,26 @@ import { useAuth } from '../context/AuthContext';
 import { supabase } from '../db/supabase';
 
 const ProtectedRoute = ({ children }) => {
-  // ✅ Read directly from our global context
+  // 1. Read directly from our global context
   const { currentUser, loading } = useAuth();
 
-  // Wait for the context to finish fetching
+  // 2. Wait for the context to finish fetching session/user data
   if (loading) return null;
 
-<<<<<<< HEAD
-    supabase
-      .from('user')
-      .select('record_status')
-      .eq('userid', session.user.id)
-      .single()
-      .then(({ data, error }) => {
-        if (error || !data) { setStatus('inactive'); return; }
-        setStatus(data.record_status === 'ACTIVE' ? 'active' : 'inactive');
-      });
-  }, [session]);
-=======
-  // No user logged in? Send to login.
-  if (!currentUser) return <Navigate to="/login" replace />;
->>>>>>> e09bf2d299d65d5f86a9f0ee0328271d89bfc7d9
+  // 3. No user logged in? Send to login.
+  if (!currentUser) {
+    return <Navigate to="/login" replace />;
+  }
 
-  // User is logged in, but their account isn't activated yet? Kick them out.
+  // 4. Check account activation
+  // AuthContext already merged 'record_status' into currentUser for us.
   if (currentUser.record_status !== 'ACTIVE') {
+    // If they aren't active, sign them out of Supabase and redirect
     supabase.auth.signOut();
     return <Navigate to="/login?error=inactive" replace />;
   }
 
-  // If they pass all checks, render the page!
+  // 5. If they pass all checks, render the page (children)
   return children;
 };
 

--- a/src/router/ProtectedRoute.jsx
+++ b/src/router/ProtectedRoute.jsx
@@ -11,7 +11,7 @@ const ProtectedRoute = ({ children, session }) => {
     supabase
       .from('user')
       .select('record_status')
-      .eq('id', session.user.id)
+      .eq('userid', session.user.id)
       .single()
       .then(({ data, error }) => {
         if (error || !data) { setStatus('inactive'); return; }


### PR DESCRIPTION
### **PR-05: feat/rights-context**

## What Changed
- Replaced UserRightsContext.jsx with correct implementation
  that queries user_module_rights table from the database
- Built rights map { PRD_ADD: 1, PRD_EDIT: 1, ... } from DB rows
- Added canAccessAdmin and canViewDeleted convenience flags
- Updated App.jsx to check rightsLoading before evaluating
  route access to prevent race condition on page load
- /admin and /deleted-items now redirect USER accounts to /products

## Why It Was Needed
Previous UserRightsContext used hardcoded wrong role values
('Admin' instead of 'ADMIN') and never queried the database.
Route guard for /deleted-items was missing entirely.

## How to Test
1. Login as USER → navigate to /deleted-items → should redirect
   to /products
2. Login as USER → navigate to /admin → should redirect
   to /products
3. Login as SUPERADMIN → navigate to /deleted-items → should
   render Deleted Items page
4. Login as ADMIN → navigate to /admin → should render
   Admin Dashboard page
5. Refresh page as SUPERADMIN on /deleted-items → should not
   flicker or redirect (rightsLoading guard prevents this)

## Notes
- rights map keys match rubric exactly: PRD_ADD, PRD_EDIT,
  PRD_DEL, REP_001, REP_002, ADM_USER
- M2 can now use rights.PRD_ADD === 1 for button gating
- M4 can use the same useRights() hook for sidebar gating