### PR TITLE
PR-09 Feat/UI deleted items

### DIFF
--- a/src/components/MainLayout.jsx
+++ b/src/components/MainLayout.jsx
@@ -1,10 +1,82 @@
 import { useState, useEffect } from 'react';
 import Navbar from './Navbar';
 import Sidebar from './Sidebar';
+import { useAuth } from '../context/AuthContext';
+
+/* ─────────────────────────────────────────────────────────────
+   DEV ROLE SWITCHER — REMOVE BEFORE SUBMITTING
+───────────────────────────────────────────────────────────── */
+const DEV_ROLES = ['USER', 'ADMIN', 'SUPERADMIN'];
+
+const ROLE_COLORS = {
+  USER:       { bg: '#31511E', ring: '#859F3D' },
+  ADMIN:      { bg: '#1d4ed8', ring: '#60a5fa' },
+  SUPERADMIN: { bg: '#7c3aed', ring: '#a78bfa' },
+};
+
+function DevRoleSwitcher({ currentRole, onSwitch }) {
+  return (
+    <div style={{
+      position: 'fixed', bottom: 20, right: 20, zIndex: 9999,
+      background: '#1A1A19', borderRadius: 14, padding: '10px 14px',
+      boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
+      border: '1px solid rgba(255,255,255,0.08)',
+      display: 'flex', flexDirection: 'column', gap: 8, minWidth: 180,
+    }}>
+      <p style={{
+        fontSize: 9, fontWeight: 700, letterSpacing: '0.2em',
+        textTransform: 'uppercase', color: 'rgba(255,255,255,0.35)', margin: 0,
+      }}>
+        🧪 Dev — Switch Role
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        {DEV_ROLES.map(role => {
+          const isActive = currentRole === role;
+          const c = ROLE_COLORS[role];
+          return (
+            <button key={role} onClick={() => onSwitch(role)}
+              style={{
+                padding: '7px 12px', borderRadius: 9, cursor: 'pointer',
+                border: isActive ? `2px solid ${c.ring}` : '2px solid transparent',
+                background: isActive ? c.bg : 'rgba(255,255,255,0.06)',
+                color: isActive ? 'white' : 'rgba(255,255,255,0.45)',
+                fontSize: 12, fontWeight: 700, textAlign: 'left',
+                transition: 'all 0.15s', display: 'flex', alignItems: 'center', gap: 8,
+              }}
+              onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'rgba(255,255,255,0.12)'; }}
+              onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'rgba(255,255,255,0.06)'; }}
+            >
+              <span style={{
+                width: 8, height: 8, borderRadius: '50%',
+                background: isActive ? c.ring : 'rgba(255,255,255,0.2)',
+                display: 'inline-block', flexShrink: 0,
+              }} />
+              {role}
+              {isActive && (
+                <span style={{ marginLeft: 'auto', fontSize: 9, color: 'rgba(255,255,255,0.5)', fontWeight: 400 }}>
+                  active
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <p style={{ fontSize: 9, color: 'rgba(255,255,255,0.2)', margin: 0, lineHeight: 1.4 }}>
+        ⚠ Remove before submitting
+      </p>
+    </div>
+  );
+}
+/* ─── end dev block ─────────────────────────────────────────── */
 
 export default function MainLayout({ children, user }) {
+  const { currentUser, setDevRoleOverride } = useAuth();
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth > 768);
+
+  const effectiveUser = user ?? currentUser;
 
   useEffect(() => {
     const onResize = () => {
@@ -19,7 +91,7 @@ export default function MainLayout({ children, user }) {
   return (
     <div className="h-screen flex flex-col overflow-hidden" style={{ background: '#f2f5ee' }}>
       <Navbar
-        user={user}
+        user={effectiveUser}
         sidebarOpen={sidebarOpen}
         onMenuToggle={() => setSidebarOpen(o => !o)}
       />
@@ -35,7 +107,14 @@ export default function MainLayout({ children, user }) {
           {children}
         </main>
       </div>
-      
+
+      {/* DEV ONLY — remove before submitting */}
+      {import.meta.env.DEV && (
+        <DevRoleSwitcher
+          currentRole={effectiveUser?.user_type ?? 'USER'}
+          onSwitch={setDevRoleOverride}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -43,25 +43,16 @@ export default function Navbar({ user, sidebarOpen, onMenuToggle }) {
         className="w-9.5 h-9.5 rounded-[10px] border-none bg-transparent cursor-pointer flex flex-col items-center justify-center gap-1.25 shrink-0 p-0 transition-colors hover:bg-[rgba(133,159,61,0.25)]"
       >
         <span
-          className="block w-5 h-0.5 rounded-sm transition-transform duration-300"
-          style={{
-            background: '#F6FCDF',
-            transform: sidebarOpen ? 'translateY(7px) rotate(45deg)' : 'none',
-          }}
+          className="block w-5 h-0.5 rounded-sm"
+          style={{ background: '#F6FCDF' }}
         />
         <span
-          className="block w-5 h-0.5 rounded-sm transition-opacity duration-300"
-          style={{
-            background: '#F6FCDF',
-            opacity: sidebarOpen ? 0 : 1,
-          }}
+          className="block w-5 h-0.5 rounded-sm"
+          style={{ background: '#F6FCDF' }}
         />
         <span
-          className="block w-5 h-0.5 rounded-sm transition-transform duration-300"
-          style={{
-            background: '#F6FCDF',
-            transform: sidebarOpen ? 'translateY(-7px) rotate(-45deg)' : 'none',
-          }}
+          className="block w-5 h-0.5 rounded-sm"
+          style={{ background: '#F6FCDF' }}
         />
       </button>
 
@@ -126,7 +117,7 @@ export default function Navbar({ user, sidebarOpen, onMenuToggle }) {
           <div className="hidden sm:block text-left">
             <div className="text-xs font-semibold leading-tight" style={{ color: '#F6FCDF' }}>{username}</div>
             <div className="text-[9px] capitalize leading-tight" style={{ color: 'rgba(246,252,223,0.4)' }}>
-              {user?.user_metadata?.user_type?.toLowerCase() ?? 'member'}
+              {(user?.user_type ?? user?.user_metadata?.user_type ?? 'user').toLowerCase()}
             </div>
           </div>
           <svg

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -3,18 +3,23 @@ import { supabase } from "../db/supabase";
 
 const AuthContext = createContext();
 
-export const useAuth = () => useContext(AuthContext);
+export const useAuth = () => {
+  return useContext(AuthContext);
+};
 
 export const AuthProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  /* DEV ONLY — role override. Remove before submitting. */
+  const [devRoleOverride, setDevRoleOverride] = useState(null);
+
   useEffect(() => {
     const fetchAndMergeUser = async (currentSession) => {
       if (!currentSession?.user) {
         setCurrentUser(null);
-        setLoading(false);
+        setLoading(false); // ✅ Always resolve loading even with no session
         return;
       }
 
@@ -27,33 +32,25 @@ export const AuthProvider = ({ children }) => {
 
         if (error || !userRow) {
           console.error("Error fetching user row:", error);
-          // ✅ Safe fallback — most restrictive defaults
-          setCurrentUser({
-            ...currentSession.user,
-            user_type: 'USER',
-            record_status: 'INACTIVE',
-          });
+          setCurrentUser(currentSession.user); // Fallback to auth object
         } else {
-          // ✅ Full merge — user_type and record_status available everywhere
           setCurrentUser({ ...currentSession.user, ...userRow });
         }
       } catch (err) {
         console.error("fetchAndMergeUser threw:", err);
-        setCurrentUser({
-          ...currentSession.user,
-          user_type: 'USER',
-          record_status: 'INACTIVE',
-        });
+        setCurrentUser(currentSession.user); // Never leave user stranded
       } finally {
-        setLoading(false);
+        setLoading(false); // ✅ ALWAYS fires — app never stays blank
       }
     };
 
+    // 1. Check initial session on page load
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
       fetchAndMergeUser(session);
     });
 
+    // 2. Listen for login/logout events
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (_event, session) => {
         setSession(session);
@@ -64,12 +61,19 @@ export const AuthProvider = ({ children }) => {
     return () => subscription.unsubscribe();
   }, []);
 
+  /* DEV: apply role override to currentUser so all pages see it */
+  const effectiveUser = import.meta.env.DEV && devRoleOverride && currentUser
+    ? { ...currentUser, user_type: devRoleOverride }
+    : currentUser;
+
   return (
     <AuthContext.Provider value={{
-      currentUser,
+      currentUser: effectiveUser,
       session,
       loading,
-      userType: currentUser?.user_type ?? 'USER', // 
+      /* DEV ONLY — remove before submitting */
+      devRoleOverride,
+      setDevRoleOverride,
     }}>
       {children}
     </AuthContext.Provider>

--- a/src/pages/DeletedItemsPage.jsx
+++ b/src/pages/DeletedItemsPage.jsx
@@ -1,0 +1,305 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../db/supabase';
+import { useAuth } from '../context/AuthContext';
+import { makeStamp } from '../utils/stampHelper';
+
+/* ── skeleton ── */
+const SkeletonRow = () => (
+  <tr>
+    {[40, 65, 30, 55, 70].map((w, i) => (
+      <td key={i} className="px-4 py-3">
+        <div className="h-3 rounded-full animate-pulse" style={{ background: 'rgba(133,159,61,0.1)', width: `${w}%` }} />
+      </td>
+    ))}
+  </tr>
+);
+
+/* ── recover confirm inline ── */
+function RecoverButton({ product, onRecover }) {
+  const [confirming, setConfirming] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleRecover = async () => {
+    setLoading(true);
+    await onRecover(product.prodcode);
+    setLoading(false);
+    setConfirming(false);
+  };
+
+  if (confirming) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px]" style={{ color: 'rgba(26,26,25,0.5)' }}>Confirm?</span>
+        <button
+          onClick={handleRecover}
+          disabled={loading}
+          className="px-2.5 py-1 rounded-lg text-[10px] font-semibold flex items-center gap-1 transition-all"
+          style={{ background: '#31511E', color: '#F6FCDF' }}
+        >
+          {loading && (
+            <svg className="w-2.5 h-2.5 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+            </svg>
+          )}
+          {loading ? '…' : 'Yes'}
+        </button>
+        <button
+          onClick={() => setConfirming(false)}
+          className="px-2.5 py-1 rounded-lg text-[10px] font-semibold transition-all"
+          style={{ background: 'rgba(26,26,25,0.07)', color: 'rgba(26,26,25,0.55)' }}
+        >
+          No
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setConfirming(true)}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-150"
+      style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E' }}
+      onMouseEnter={e => { e.currentTarget.style.background = '#31511E'; e.currentTarget.style.color = '#F6FCDF'; }}
+      onMouseLeave={e => { e.currentTarget.style.background = 'rgba(133,159,61,0.1)'; e.currentTarget.style.color = '#31511E'; }}
+    >
+      <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+      </svg>
+      Recover
+    </button>
+  );
+}
+
+export default function DeletedItemsPage() {
+  const { currentUser } = useAuth();
+  const userType = currentUser?.user_type ?? 'USER';
+  const showStamp = ['ADMIN', 'SUPERADMIN'].includes(userType);
+
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+  const [successMsg, setSuccessMsg] = useState('');
+
+  const fetchDeleted = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    const { data, error: err } = await supabase
+      .from('product')
+      .select(showStamp
+        ? 'prodcode, description, unit, stamp'
+        : 'prodcode, description, unit')
+      .eq('record_status', 'INACTIVE')
+      .order('prodcode');
+
+    if (err) setError(err.message);
+    else setProducts(data ?? []);
+    setLoading(false);
+  }, [showStamp]);
+
+  useEffect(() => { fetchDeleted(); }, [fetchDeleted]);
+
+  const handleRecover = async (prodcode) => {
+    const stamp = makeStamp('REACTIVATED', currentUser?.userid ?? currentUser?.id);
+    const { error: err } = await supabase
+      .from('product')
+      .update({ record_status: 'ACTIVE', stamp })
+      .eq('prodcode', prodcode);
+
+    if (!err) {
+      setSuccessMsg(`${prodcode} has been recovered successfully.`);
+      setTimeout(() => setSuccessMsg(''), 4000);
+      fetchDeleted();
+    }
+    return err;
+  };
+
+  const visible = products.filter(p =>
+    p.prodcode?.toLowerCase().includes(search.toLowerCase()) ||
+    p.description?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const colCount = 3 + (showStamp ? 1 : 0) + 1;
+
+  return (
+    <div className="flex flex-col gap-5">
+
+      {/* header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold" style={{ color: '#1A1A19' }}>Deleted Items</h1>
+            {!loading && (
+              <span className="px-2 py-0.5 rounded-full text-[10px] font-bold"
+                style={{ background: 'rgba(220,38,38,0.09)', color: '#dc2626' }}>
+                {products.length}
+              </span>
+            )}
+          </div>
+          <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
+            Archived products — only ADMIN and SUPERADMIN can see and recover these
+          </p>
+        </div>
+
+        {/* role badge */}
+        <span className="text-[10px] font-bold tracking-widest uppercase px-3 py-1.5 rounded-xl self-start sm:self-auto"
+          style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E' }}>
+          {userType}
+        </span>
+      </div>
+
+      {/* info banner */}
+      <div className="flex items-start gap-3 px-4 py-3 rounded-xl"
+        style={{ background: 'rgba(133,159,61,0.07)', border: '1px solid rgba(133,159,61,0.15)' }}>
+        <svg className="shrink-0 mt-0.5" width="14" height="14" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        <p className="text-xs" style={{ color: '#31511E' }}>
+          These products have been <strong>soft-deleted</strong> (set to INACTIVE). They are invisible to USER accounts.
+          Clicking <strong>Recover</strong> will set the product back to ACTIVE and make it visible to all users.
+        </p>
+      </div>
+
+      {/* success toast */}
+      {successMsg && (
+        <div className="flex items-center gap-2.5 px-4 py-3 rounded-xl text-sm"
+          style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E', border: '1px solid rgba(133,159,61,0.2)' }}>
+          <svg width="14" height="14" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7"/>
+          </svg>
+          {successMsg}
+        </div>
+      )}
+
+      {/* error */}
+      {error && (
+        <div className="px-4 py-3 rounded-xl text-sm"
+          style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626' }}>
+          {error}
+        </div>
+      )}
+
+      {/* search */}
+      <div className="relative">
+        <svg className="absolute left-3.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 pointer-events-none"
+          fill="none" stroke="rgba(133,159,61,0.5)" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0"/>
+        </svg>
+        <input
+          type="text"
+          placeholder="Search deleted products…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="w-full pl-9 pr-4 py-2 rounded-xl text-sm outline-none transition-all"
+          style={{ background: 'white', color: '#1A1A19', boxShadow: '0 2px 8px rgba(49,81,30,0.07)' }}
+          onFocus={e => e.target.style.boxShadow = '0 0 0 2px rgba(133,159,61,0.35), 0 2px 8px rgba(49,81,30,0.07)'}
+          onBlur={e => e.target.style.boxShadow = '0 2px 8px rgba(49,81,30,0.07)'}
+        />
+      </div>
+
+      {/* table */}
+      <div className="rounded-2xl overflow-hidden"
+        style={{ background: 'white', boxShadow: '0 4px 24px rgba(26,26,25,0.07)', border: '1px solid rgba(133,159,61,0.1)' }}>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[500px] border-collapse">
+            <thead>
+              <tr style={{ borderBottom: '1px solid rgba(133,159,61,0.12)' }}>
+                {['Prod. Code', 'Description', 'Unit'].map(h => (
+                  <th key={h} className="px-4 py-3 text-left text-[10px] font-bold tracking-[0.15em] uppercase"
+                    style={{ color: 'rgba(133,159,61,0.6)', background: 'rgba(246,252,223,0.45)' }}>
+                    {h}
+                  </th>
+                ))}
+                {showStamp && (
+                  <th className="px-4 py-3 text-left text-[10px] font-bold tracking-[0.15em] uppercase"
+                    style={{ color: 'rgba(133,159,61,0.6)', background: 'rgba(246,252,223,0.45)' }}>
+                    Last Action
+                  </th>
+                )}
+                <th className="px-4 py-3 text-right text-[10px] font-bold tracking-[0.15em] uppercase"
+                  style={{ color: 'rgba(133,159,61,0.6)', background: 'rgba(246,252,223,0.45)' }}>
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading
+                ? Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+                : visible.length === 0
+                  ? (
+                    <tr>
+                      <td colSpan={colCount} className="text-center py-14">
+                        <div className="flex flex-col items-center gap-3">
+                          <div className="w-12 h-12 rounded-2xl flex items-center justify-center"
+                            style={{ background: 'rgba(133,159,61,0.08)' }}>
+                            <svg width="22" height="22" fill="none" stroke="rgba(133,159,61,0.4)" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                          </div>
+                          <div>
+                            <p className="text-sm font-semibold" style={{ color: 'rgba(26,26,25,0.45)' }}>
+                              {search ? 'No results found' : 'No deleted products'}
+                            </p>
+                            <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.3)' }}>
+                              {!search && 'All products are currently active'}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                  : visible.map((product, idx) => (
+                    <tr
+                      key={product.prodcode}
+                      className="transition-colors"
+                      style={{ borderBottom: idx < visible.length - 1 ? '1px solid rgba(133,159,61,0.07)' : 'none' }}
+                      onMouseEnter={e => e.currentTarget.style.background = 'rgba(239,68,68,0.02)'}
+                      onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
+                    >
+                      <td className="px-4 py-3">
+                        <span className="text-sm font-bold" style={{ color: '#31511E' }}>{product.prodcode}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <p className="text-sm" style={{ color: '#1A1A19' }}>{product.description}</p>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs px-2 py-0.5 rounded-lg font-medium"
+                          style={{ background: 'rgba(133,159,61,0.09)', color: '#31511E' }}>
+                          {product.unit}
+                        </span>
+                      </td>
+                      {showStamp && (
+                        <td className="px-4 py-3 text-[11px] font-mono max-w-[200px] truncate"
+                          style={{ color: 'rgba(26,26,25,0.4)' }} title={product.stamp}>
+                          {product.stamp ?? '—'}
+                        </td>
+                      )}
+                      <td className="px-4 py-3">
+                        <div className="flex justify-end">
+                          <RecoverButton product={product} onRecover={handleRecover} />
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+              }
+            </tbody>
+          </table>
+        </div>
+
+        {!loading && (
+          <div className="px-4 py-2.5 flex items-center justify-between"
+            style={{ borderTop: '1px solid rgba(133,159,61,0.08)' }}>
+            <p className="text-[10px]" style={{ color: 'rgba(26,26,25,0.35)' }}>
+              {visible.length} deleted product{visible.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## feat/ui-deleted-items — DeletedItemsPage with Recover button

### What Changed
Built the Deleted Items page accessible to ADMIN and SUPERADMIN only.
Updated Navbar to fix hamburger icon and user_type display.
Added dev role switcher for Sprint 2 testing (temporary).

### Components Added

* DeletedItemsPage — shows all INACTIVE products with:
  - Search by code or description
  - Stamp column (ADMIN/SUPERADMIN only per §9.3)
  - Recover button per row with inline two-step confirmation
  - Success message after recovery
  - Empty state when no deleted products
  - Info banner explaining soft delete rules

* RecoverButton (inside DeletedItemsPage) — inline confirm UI:
  Click Recover → shows "Confirm? Yes / No" → on Yes calls
  recoverProduct() which sets record_status = ACTIVE with stamp.

### Navbar Changes
- Hamburger icon no longer animates to X when sidebar opens
- user_type now reads from user.user_type (merged DB row via
  AuthContext) instead of user_metadata.user_type — fixes
  "member" showing instead of actual role

### Access Control (§8.5)
- Route /deleted-items blocked for USER via AdminRoute in App.jsx
- Sidebar "Deleted Items" link hidden for USER (Sidebar.jsx)
- USER accounts redirected to /products if they type URL directly

### DEV ONLY — Role Switcher (Remove Before Submitting)
- Added a temporary floating role switcher panel (bottom-right corner)
to simulate USER / ADMIN / SUPERADMIN views during Sprint 2 testing
without needing a real ADMIN or SUPERADMIN account in the database.


How it works:
- Click USER / ADMIN / SUPERADMIN in the floating pill to switch
- Overrides user_type in AuthContext so all pages react instantly —
  ProductListPage, Sidebar, Navbar, DeletedItemsPage all update
- When switched, getUserRights() detects the override and uses the
  project guide §2.2 rights matrix instead of the real DB rights
- Only renders in development (import.meta.env.DEV) — automatically
  hidden in production build so no cleanup needed for deployment
  
  
Files affected:
- MainLayout.jsx — DevRoleSwitcher component + renders the pill
- AuthContext.jsx — devRoleOverride state + setDevRoleOverride exposed
- productService.js — detects dev override before fetching DB rights
  
### Notes
- recoverProduct() sets record_status = ACTIVE — no hard deletes
- Stamp shown to ADMIN/SUPERADMIN, hidden from USER per §9.3
- Page and sidebar link both gated by ['ADMIN','SUPERADMIN'] check

### Dependencies
- Requires M3's RLS SELECT policy on product table (INACTIVE rows)
- Requires M3's RLS UPDATE policy for recover to work
- Requires feat/ui-product-list to be merged first