### PR TITLE
PR-11 feat/ui-product-crud 

### DIFF
--- a/src/components/AddProductModal.jsx
+++ b/src/components/AddProductModal.jsx
@@ -72,7 +72,7 @@ export default function AddProductModal({ currentUser, onClose, onSuccess }) {
             maxLength={6}
             placeholder="e.g. AK0001"
             value={form.prodcode}
-            onChange={e => set('prodcode', e.target.value)}
+            onChange={e => set('prodcode', e.target.value.toUpperCase())}
             className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-all uppercase"
             style={inputStyle(errors.prodcode)}
             onFocus={e => e.target.style.boxShadow = '0 0 0 2px rgba(133,159,61,0.45), 0 2px 8px rgba(49,81,30,0.06)'}
@@ -87,6 +87,7 @@ export default function AddProductModal({ currentUser, onClose, onSuccess }) {
             placeholder="Product description (max 30 chars)"
             value={form.description}
             onChange={e => set('description', e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
             className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-all"
             style={inputStyle(errors.description)}
             onFocus={e => e.target.style.boxShadow = '0 0 0 2px rgba(133,159,61,0.45), 0 2px 8px rgba(49,81,30,0.06)'}

--- a/src/components/AddProductModal.jsx
+++ b/src/components/AddProductModal.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { supabase } from '../db/supabase';
-import { makeStamp } from '../utils/stampHelper';
+import { addProduct } from '../services/productService';
 
 const UNITS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
 
@@ -44,20 +43,15 @@ export default function AddProductModal({ currentUser, onClose, onSuccess }) {
     setSubmitting(true);
     setServerError('');
 
-    const stamp = makeStamp('ADDED', currentUser?.userid ?? currentUser?.id);
-    const { error } = await supabase.from('product').insert({
-      prodcode: form.prodcode.trim().toUpperCase(),
-      description: form.description.trim(),
-      unit: form.unit,
-      record_status: 'ACTIVE',
-      stamp,
-    });
-
-    if (error) {
+    try {
+      await addProduct(
+        { prodcode: form.prodcode, description: form.description, unit: form.unit },
+        currentUser?.userid ?? currentUser?.id
+      );
+      onSuccess();
+    } catch (error) {
       setServerError(error.code === '23505' ? 'Product code already exists.' : error.message);
       setSubmitting(false);
-    } else {
-      onSuccess();
     }
   };
 

--- a/src/components/AddProductModal.jsx
+++ b/src/components/AddProductModal.jsx
@@ -1,0 +1,210 @@
+import { useState } from 'react';
+import { supabase } from '../db/supabase';
+import { makeStamp } from '../utils/stampHelper';
+
+const UNITS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
+
+const Field = ({ label, error, children }) => (
+  <div className="flex flex-col gap-1">
+    <label className="text-[10px] tracking-[0.18em] font-semibold uppercase"
+      style={{ color: 'rgba(49,81,30,0.65)' }}>
+      {label}
+    </label>
+    {children}
+    {error && (
+      <p className="text-[10px]" style={{ color: '#dc2626' }}>{error}</p>
+    )}
+  </div>
+);
+
+export default function AddProductModal({ currentUser, onClose, onSuccess }) {
+  const [form, setForm] = useState({ prodcode: '', description: '', unit: 'pc' });
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState('');
+
+  const set = (key, val) => {
+    setForm(f => ({ ...f, [key]: val }));
+    setErrors(e => ({ ...e, [key]: '' }));
+  };
+
+  const validate = () => {
+    const e = {};
+    if (!form.prodcode.trim()) e.prodcode = 'Product code is required';
+    else if (!/^[A-Za-z0-9]{1,6}$/.test(form.prodcode.trim())) e.prodcode = 'Max 6 alphanumeric characters';
+    if (!form.description.trim()) e.description = 'Description is required';
+    else if (form.description.trim().length > 30) e.description = 'Max 30 characters';
+    if (!form.unit) e.unit = 'Unit is required';
+    return e;
+  };
+
+  const handleSubmit = async () => {
+    const e = validate();
+    if (Object.keys(e).length) { setErrors(e); return; }
+    setSubmitting(true);
+    setServerError('');
+
+    const stamp = makeStamp('ADDED', currentUser?.userid ?? currentUser?.id);
+    const { error } = await supabase.from('product').insert({
+      prodcode: form.prodcode.trim().toUpperCase(),
+      description: form.description.trim(),
+      unit: form.unit,
+      record_status: 'ACTIVE',
+      stamp,
+    });
+
+    if (error) {
+      setServerError(error.code === '23505' ? 'Product code already exists.' : error.message);
+      setSubmitting(false);
+    } else {
+      onSuccess();
+    }
+  };
+
+  const inputStyle = (err) => ({
+    background: 'white',
+    color: '#1A1A19',
+    boxShadow: err
+      ? '0 0 0 2px rgba(239,68,68,0.4), 0 2px 8px rgba(49,81,30,0.06)'
+      : '0 2px 8px rgba(49,81,30,0.06)',
+  });
+
+  return (
+    <ModalShell title="Add Product" onClose={onClose}>
+      <div className="flex flex-col gap-4">
+        <Field label="Product Code" error={errors.prodcode}>
+          <input
+            type="text"
+            maxLength={6}
+            placeholder="e.g. AK0001"
+            value={form.prodcode}
+            onChange={e => set('prodcode', e.target.value)}
+            className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-all uppercase"
+            style={inputStyle(errors.prodcode)}
+            onFocus={e => e.target.style.boxShadow = '0 0 0 2px rgba(133,159,61,0.45), 0 2px 8px rgba(49,81,30,0.06)'}
+            onBlur={e => e.target.style.boxShadow = inputStyle(errors.prodcode).boxShadow}
+          />
+        </Field>
+
+        <Field label="Description" error={errors.description}>
+          <input
+            type="text"
+            maxLength={30}
+            placeholder="Product description (max 30 chars)"
+            value={form.description}
+            onChange={e => set('description', e.target.value)}
+            className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-all"
+            style={inputStyle(errors.description)}
+            onFocus={e => e.target.style.boxShadow = '0 0 0 2px rgba(133,159,61,0.45), 0 2px 8px rgba(49,81,30,0.06)'}
+            onBlur={e => e.target.style.boxShadow = inputStyle(errors.description).boxShadow}
+          />
+          <p className="text-[10px] text-right" style={{ color: 'rgba(26,26,25,0.3)' }}>
+            {form.description.length}/30
+          </p>
+        </Field>
+
+        <Field label="Unit" error={errors.unit}>
+          <div className="flex gap-2 flex-wrap">
+            {UNITS.map(u => (
+              <button
+                key={u}
+                type="button"
+                onClick={() => set('unit', u)}
+                className="px-3.5 py-1.5 rounded-xl text-sm font-medium transition-all duration-150"
+                style={{
+                  background: form.unit === u ? '#31511E' : 'white',
+                  color: form.unit === u ? '#F6FCDF' : 'rgba(26,26,25,0.55)',
+                  boxShadow: form.unit === u
+                    ? '0 2px 8px rgba(49,81,30,0.2)'
+                    : '0 2px 8px rgba(49,81,30,0.06)',
+                }}
+              >
+                {u}
+              </button>
+            ))}
+          </div>
+        </Field>
+
+        {serverError && (
+          <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl text-[12px]"
+            style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.18)' }}>
+            <svg width="13" height="13" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+            </svg>
+            {serverError}
+          </div>
+        )}
+
+        <div className="flex gap-2.5 pt-1">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all"
+            style={{ background: 'rgba(133,159,61,0.09)', color: '#31511E' }}
+            onMouseEnter={e => e.currentTarget.style.background = 'rgba(133,159,61,0.16)'}
+            onMouseLeave={e => e.currentTarget.style.background = 'rgba(133,159,61,0.09)'}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-2"
+            style={{
+              background: submitting ? 'rgba(49,81,30,0.5)' : '#31511E',
+              color: '#F6FCDF',
+              boxShadow: '0 2px 10px rgba(49,81,30,0.22)',
+            }}
+          >
+            {submitting && (
+              <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+              </svg>
+            )}
+            {submitting ? 'Saving…' : 'Add Product'}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+/* ── shared modal shell ─────────────────────────────── */
+export function ModalShell({ title, onClose, children, width = 'max-w-md' }) {
+  return (
+    <div
+      className="fixed inset-0 z-300 flex items-center justify-center p-4"
+      style={{ background: 'rgba(26,26,25,0.45)', backdropFilter: 'blur(4px)' }}
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className={`w-full ${width} rounded-2xl overflow-hidden`}
+        style={{
+          background: '#f2f5ee',
+          boxShadow: '0 24px 64px rgba(26,26,25,0.22)',
+          border: '1px solid rgba(133,159,61,0.15)',
+        }}
+      >
+        {/* header */}
+        <div className="flex items-center justify-between px-5 py-4"
+          style={{ borderBottom: '1px solid rgba(133,159,61,0.1)' }}>
+          <h2 className="text-base font-bold" style={{ color: '#1A1A19' }}>{title}</h2>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-lg flex items-center justify-center transition-all"
+            style={{ color: 'rgba(26,26,25,0.4)' }}
+            onMouseEnter={e => { e.currentTarget.style.background = 'rgba(133,159,61,0.12)'; e.currentTarget.style.color = '#1A1A19'; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'rgba(26,26,25,0.4)'; }}
+          >
+            <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+        {/* body */}
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditProductModal.jsx
+++ b/src/components/EditProductModal.jsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import { supabase } from '../db/supabase';
+import { makeStamp } from '../utils/stampHelper';
+import { ModalShell } from './AddProductModal';
+
+const UNITS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
+
+const Field = ({ label, error, children }) => (
+  <div className="flex flex-col gap-1">
+    <label className="text-[10px] tracking-[0.18em] font-semibold uppercase"
+      style={{ color: 'rgba(49,81,30,0.65)' }}>
+      {label}
+    </label>
+    {children}
+    {error && <p className="text-[10px]" style={{ color: '#dc2626' }}>{error}</p>}
+  </div>
+);
+
+export default function EditProductModal({ product, currentUser, onClose, onSuccess }) {
+  const [form, setForm] = useState({
+    description: product.description ?? '',
+    unit: product.unit ?? 'pc',
+  });
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState('');
+
+  const set = (key, val) => {
+    setForm(f => ({ ...f, [key]: val }));
+    setErrors(e => ({ ...e, [key]: '' }));
+  };
+
+  const validate = () => {
+    const e = {};
+    if (!form.description.trim()) e.description = 'Description is required';
+    else if (form.description.trim().length > 30) e.description = 'Max 30 characters';
+    if (!form.unit) e.unit = 'Unit is required';
+    return e;
+  };
+
+  const handleSubmit = async () => {
+    const e = validate();
+    if (Object.keys(e).length) { setErrors(e); return; }
+    setSubmitting(true);
+    setServerError('');
+
+    const stamp = makeStamp('EDITED', currentUser?.userid ?? currentUser?.id);
+    const { error } = await supabase
+      .from('product')
+      .update({ description: form.description.trim(), unit: form.unit, stamp })
+      .eq('prodcode', product.prodcode);
+
+    if (error) {
+      setServerError(error.message);
+      setSubmitting(false);
+    } else {
+      onSuccess();
+    }
+  };
+
+  const inputStyle = (err) => ({
+    background: 'white',
+    color: '#1A1A19',
+    boxShadow: err
+      ? '0 0 0 2px rgba(239,68,68,0.4), 0 2px 8px rgba(49,81,30,0.06)'
+      : '0 2px 8px rgba(49,81,30,0.06)',
+  });
+
+  return (
+    <ModalShell title="Edit Product" onClose={onClose}>
+      <div className="flex flex-col gap-4">
+        {/* read-only code */}
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] tracking-[0.18em] font-semibold uppercase"
+            style={{ color: 'rgba(49,81,30,0.65)' }}>Product Code</label>
+          <div className="w-full rounded-xl px-3.5 py-2.5 text-sm font-bold"
+            style={{ background: 'rgba(133,159,61,0.08)', color: '#31511E' }}>
+            {product.prodcode}
+          </div>
+          <p className="text-[10px]" style={{ color: 'rgba(26,26,25,0.35)' }}>Product code cannot be changed</p>
+        </div>
+
+        <Field label="Description" error={errors.description}>
+          <input
+            type="text"
+            maxLength={30}
+            value={form.description}
+            onChange={e => set('description', e.target.value)}
+            className="w-full rounded-xl px-3.5 py-2.5 text-sm outline-none transition-all"
+            style={inputStyle(errors.description)}
+            onFocus={e => e.target.style.boxShadow = '0 0 0 2px rgba(133,159,61,0.45), 0 2px 8px rgba(49,81,30,0.06)'}
+            onBlur={e => e.target.style.boxShadow = inputStyle(errors.description).boxShadow}
+          />
+          <p className="text-[10px] text-right" style={{ color: 'rgba(26,26,25,0.3)' }}>
+            {form.description.length}/30
+          </p>
+        </Field>
+
+        <Field label="Unit" error={errors.unit}>
+          <div className="flex gap-2 flex-wrap">
+            {UNITS.map(u => (
+              <button
+                key={u}
+                type="button"
+                onClick={() => set('unit', u)}
+                className="px-3.5 py-1.5 rounded-xl text-sm font-medium transition-all duration-150"
+                style={{
+                  background: form.unit === u ? '#31511E' : 'white',
+                  color: form.unit === u ? '#F6FCDF' : 'rgba(26,26,25,0.55)',
+                  boxShadow: form.unit === u
+                    ? '0 2px 8px rgba(49,81,30,0.2)'
+                    : '0 2px 8px rgba(49,81,30,0.06)',
+                }}
+              >
+                {u}
+              </button>
+            ))}
+          </div>
+        </Field>
+
+        {serverError && (
+          <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl text-[12px]"
+            style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.18)' }}>
+            <svg width="13" height="13" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+            </svg>
+            {serverError}
+          </div>
+        )}
+
+        <div className="flex gap-2.5 pt-1">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all"
+            style={{ background: 'rgba(133,159,61,0.09)', color: '#31511E' }}
+            onMouseEnter={e => e.currentTarget.style.background = 'rgba(133,159,61,0.16)'}
+            onMouseLeave={e => e.currentTarget.style.background = 'rgba(133,159,61,0.09)'}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-2"
+            style={{
+              background: submitting ? 'rgba(49,81,30,0.5)' : '#31511E',
+              color: '#F6FCDF',
+              boxShadow: '0 2px 10px rgba(49,81,30,0.22)',
+            }}
+          >
+            {submitting && (
+              <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+              </svg>
+            )}
+            {submitting ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}

--- a/src/components/EditProductModal.jsx
+++ b/src/components/EditProductModal.jsx
@@ -40,6 +40,17 @@ export default function EditProductModal({ product, currentUser, onClose, onSucc
   const handleSubmit = async () => {
     const e = validate();
     if (Object.keys(e).length) { setErrors(e); return; }
+
+    // ✅ Dirty check — don't write to DB if nothing changed
+    const hasChanged =
+      form.description.trim() !== (product.description ?? '').trim() ||
+      form.unit !== product.unit;
+
+    if (!hasChanged) {
+      onClose(); // nothing changed — just close
+      return;
+    }
+
     setSubmitting(true);
     setServerError('');
 

--- a/src/components/EditProductModal.jsx
+++ b/src/components/EditProductModal.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { supabase } from '../db/supabase';
-import { makeStamp } from '../utils/stampHelper';
+import { updateProduct } from '../services/productService';
 import { ModalShell } from './AddProductModal';
 
 const UNITS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
@@ -44,17 +43,16 @@ export default function EditProductModal({ product, currentUser, onClose, onSucc
     setSubmitting(true);
     setServerError('');
 
-    const stamp = makeStamp('EDITED', currentUser?.userid ?? currentUser?.id);
-    const { error } = await supabase
-      .from('product')
-      .update({ description: form.description.trim(), unit: form.unit, stamp })
-      .eq('prodcode', product.prodcode);
-
-    if (error) {
+    try {
+      await updateProduct(
+        product.prodcode,
+        { description: form.description, unit: form.unit },
+        currentUser?.userid ?? currentUser?.id
+      );
+      onSuccess();
+    } catch (error) {
       setServerError(error.message);
       setSubmitting(false);
-    } else {
-      onSuccess();
     }
   };
 

--- a/src/components/SoftDeleteConfirmDialog.jsx
+++ b/src/components/SoftDeleteConfirmDialog.jsx
@@ -17,7 +17,7 @@ export default function SoftDeleteConfirmDialog({ product, onClose, onConfirm })
   };
 
   return (
-    <ModalShell title="Soft Delete Product" onClose={onClose}>
+    <ModalShell title="Soft Delete Product" onClose={loading ? () => {} : onClose}>
       <div className="flex flex-col gap-5">
         {/* warning icon */}
         <div className="flex flex-col items-center gap-3 py-2">

--- a/src/components/SoftDeleteConfirmDialog.jsx
+++ b/src/components/SoftDeleteConfirmDialog.jsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { ModalShell } from './AddProductModal';
+
+export default function SoftDeleteConfirmDialog({ product, onClose, onConfirm }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    setError('');
+    const err = await onConfirm();
+    if (err) {
+      setError(err.message ?? 'Something went wrong.');
+      setLoading(false);
+    }
+    // onConfirm handles closing on success
+  };
+
+  return (
+    <ModalShell title="Soft Delete Product" onClose={onClose}>
+      <div className="flex flex-col gap-5">
+        {/* warning icon */}
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="w-14 h-14 rounded-2xl flex items-center justify-center"
+            style={{ background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.15)' }}>
+            <svg width="26" height="26" fill="none" stroke="#dc2626" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+            </svg>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>
+              Deactivate this product?
+            </p>
+            <p className="text-[12px] mt-1 max-w-xs" style={{ color: 'rgba(26,26,25,0.5)' }}>
+              This will set the product to <strong style={{ color: '#dc2626' }}>INACTIVE</strong> and hide it from all USER accounts. Only admins can recover it.
+            </p>
+          </div>
+
+          {/* product info card */}
+          <div className="w-full rounded-xl px-4 py-3 flex items-center gap-3"
+            style={{ background: 'rgba(133,159,61,0.07)', border: '1px solid rgba(133,159,61,0.12)' }}>
+            <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+              style={{ background: '#31511E' }}>
+              <svg width="14" height="14" fill="white" viewBox="0 0 24 24">
+                <path d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+              </svg>
+            </div>
+            <div>
+              <p className="text-[11px] font-bold" style={{ color: '#31511E' }}>{product.prodcode}</p>
+              <p className="text-[11px]" style={{ color: 'rgba(26,26,25,0.55)' }}>{product.description}</p>
+            </div>
+            <span className="ml-auto text-[10px] font-semibold px-2 py-0.5 rounded-full"
+              style={{ background: 'rgba(133,159,61,0.12)', color: '#31511E' }}>
+              {product.unit}
+            </span>
+          </div>
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl text-[12px]"
+            style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.18)' }}>
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-2.5">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all"
+            style={{ background: 'rgba(133,159,61,0.09)', color: '#31511E' }}
+            onMouseEnter={e => e.currentTarget.style.background = 'rgba(133,159,61,0.16)'}
+            onMouseLeave={e => e.currentTarget.style.background = 'rgba(133,159,61,0.09)'}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-2"
+            style={{
+              background: loading ? 'rgba(220,38,38,0.5)' : '#dc2626',
+              color: 'white',
+              boxShadow: '0 2px 10px rgba(220,38,38,0.25)',
+            }}
+          >
+            {loading && (
+              <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+              </svg>
+            )}
+            {loading ? 'Deactivating…' : 'Yes, Deactivate'}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}


### PR DESCRIPTION
## feat/ui-product-crud — AddProductModal, EditProductModal, SoftDeleteConfirmDialog

### What Changed
Built all three product CRUD modals. These replace the temporary
stubs from PR-01 (feat/ui-product-list).
Updated all modals to use M1's productService.js instead of
calling Supabase directly.

### Files Changed
- src/components/AddProductModal.jsx         → new file
- src/components/EditProductModal.jsx        → new file
- src/components/SoftDeleteConfirmDialog.jsx → new file

### Components Added

* AddProductModal
  - prodcode field: max 6 chars, auto-uppercase, alphanumeric only
  - description field: max 30 chars with live character counter
  - unit toggle buttons: pc, ea, mtr, pkg, ltr
  - Calls addProduct() from productService on submit
  - Detects duplicate prodcode via Supabase error code 23505
  - Shows server error inline inside modal

* EditProductModal
  - prodcode displayed as read-only — cannot be changed per §3.1
    (prodcode is PRIMARY KEY, never editable)
  - Only description and unit are editable per project guide
  - Calls updateProduct() from productService on save
  - Exports shared ModalShell wrapper used by both modals

* SoftDeleteConfirmDialog
  - Two-step confirmation before deactivating product
  - Shows product info card (code, description, unit) for context
  - Calls softDeleteProduct() from productService on confirm
  - NO DELETE statement used anywhere — §8.1 Rule 1 (no hard deletes)
  - Shows server error inline if DB rejects (e.g. RLS not ready)

* ModalShell (shared)
  - Exported from AddProductModal.jsx
  - Used by both AddProductModal and EditProductModal
  - Handles backdrop click to close, X button, title, body

### Service Functions Used (M1's productService.js)
- addProduct(payload, userId) — inserts with ACTIVE status and stamp
- updateProduct(prodcode, payload, userId) — updates description
  and unit, refreshes stamp
- softDeleteProduct(prodcode, userId) — sets record_status to
  INACTIVE, no DELETE statement

### No Direct Supabase Calls
All DB operations go through M1's productService.js.
No supabase imports in any of these component files.
No makeStamp imports — stamp is handled inside productService.

### How to Replace Stubs (PR-01 → PR-02)
In ProductListPage.jsx, replace the 4 stub lines with real imports:
  import AddProductModal from '../components/AddProductModal';
  import EditProductModal from '../components/EditProductModal';
  import SoftDeleteConfirmDialog from '../components/SoftDeleteConfirmDialog';
  import PriceHistoryPanel from '../components/PriceHistoryPanel';
And remove the 4 const stub declarations above them.

### Rights Gating
- Add button only renders when PRD_ADD = 1
- Edit button only renders when PRD_EDIT = 1 and product is ACTIVE
- Delete button only renders when PRD_DEL = 1 and product is ACTIVE
  (SUPERADMIN only per §2.2 rights matrix)

### Notes
- prodcode is PRIMARY KEY — never editable per project guide §3.1
- Soft delete calls UPDATE not DELETE — no hard deletes anywhere
- ModalShell exported from AddProductModal.jsx for reuse

### Dependencies
- Requires PR-01 (feat/ui-product-list) to be merged first
- Requires M1's productService.js to be merged first
- Requires M3's RLS UPDATE policy on product table for soft delete
  to work with real SUPERADMIN account