### PR TITLE
PR-16 feat/reports-api REP_001 + REP_002 Supabase query functions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,8 +10,11 @@ import AuthCallBack from './pages/AuthCallBack';
 import MainLayout from './components/MainLayout';
 import ProductListPage from './pages/ProductListPage';
 import DeletedItemsPage from './pages/DeletedItemsPage';
+import { getProductPriceReport, getTopSellingReport } from './services/reportService';
 
 /* ── Placeholder pages — replace in Sprint 2/3 PRs ── */
+
+
 const ReportsPage = () => (
   <div className="p-4">
     <h1 className="text-xl font-bold text-[#31511E] mb-1">Reports</h1>

--- a/src/docs/db-schema.md
+++ b/src/docs/db-schema.md
@@ -60,6 +60,28 @@
 | record_status | VARCHAR      | NULL, DEFAULT 'ACTIVE'                      |
 | stamp         | VARCHAR      | NULL                                        |
 
+## sales table
+| Column      | Type    | Constraint                                      |
+|-------------|---------|-------------------------------------------------|
+| transno     | VARCHAR | PRIMARY KEY, NOT NULL                           |
+| salesdate   | DATE    | NULL                                            |
+| custno      | VARCHAR | NULL                                            |
+| empno       | VARCHAR | FOREIGN KEY (employee), NULL                    |
+
+## salesdetail table
+| Column      | Type    | Constraint                                      |
+|-------------|---------|-------------------------------------------------|
+| transno     | VARCHAR | PRIMARY KEY, FOREIGN KEY (sales), NOT NULL      |
+| prodcode    | VARCHAR | PRIMARY KEY, FOREIGN KEY (product), NOT NULL    |
+| quantity    | NUMERIC | NULL                                            |
+
+## payment table
+| Column      | Type    | Constraint                                      |
+|-------------|---------|-------------------------------------------------|
+| orno        | VARCHAR | PRIMARY KEY, NOT NULL                           |
+| paydate     | DATE    | NULL                                            |
+| amount      | NUMERIC | NULL                                            |
+| transno     | VARCHAR | FOREIGN KEY (sales), NULL                       |
 
 ## Key Rules
 - No hard deletes anywhere in the app

--- a/src/services/reportService.js
+++ b/src/services/reportService.js
@@ -1,0 +1,91 @@
+import { supabase } from '../db/supabase';
+
+/**
+ REP_001 — Product Price Report
+ Access: SUPERADMIN, ADMIN, USER (all authenticated roles)
+ 
+ Returns every ACTIVE product with its current unit price and
+ the effective date that price took effect. 
+ **/
+export async function getProductPriceReport() {
+  const { data, error } = await supabase
+    .from('product')
+    .select(`
+      prodcode,
+      description,
+      unit,
+      pricehist (
+        unitprice,
+        effdate
+      )
+    `)
+    .eq('record_status', 'ACTIVE')
+    .order('prodcode', { ascending: true });
+
+  if (error) throw error;
+
+  // Flatten: pick the latest pricehist row per product (max effdate)
+  // The nested select returns ALL pricehist rows per product,
+  // so we sort client-side and take the first (most recent).
+  return (data ?? []).map(product => {
+    const sortedPrices = (product.pricehist ?? [])
+      .slice()
+      .sort((a, b) => new Date(b.effdate) - new Date(a.effdate));
+
+    const latest = sortedPrices[0] ?? null;
+
+    return {
+      prodcode:       product.prodcode,
+      description:    product.description,
+      unit:           product.unit,
+      current_price:  latest ? Number(latest.unitprice) : null,
+      effective_date: latest ? latest.effdate : null,
+    };
+  });
+}
+
+/**
+ REP_002 — Top-Selling Products Report
+ Access: SUPERADMIN only (confidential executive/BI data)
+ 
+ Returns the top 10 products ranked by total quantity sold across
+ all sales transactions, joining salesdetail → product.
+ **/
+export async function getTopSellingReport() {
+  const { data, error } = await supabase
+    .from('salesdetail')
+    .select(`
+      prodcode,
+      quantity,
+      product (
+        description,
+        unit
+      )
+    `);
+
+  if (error) throw error;
+
+  // Aggregate total quantity sold per product
+  const totalsMap = {};
+
+  (data ?? []).forEach(row => {
+    if (!row.prodcode) return;
+
+    if (!totalsMap[row.prodcode]) {
+      totalsMap[row.prodcode] = {
+        prodcode:            row.prodcode,
+        description:         row.product?.description ?? '—',
+        unit:                row.product?.unit ?? '—',
+        total_quantity_sold: 0,
+      };
+    }
+
+    totalsMap[row.prodcode].total_quantity_sold += Number(row.quantity ?? 0);
+  });
+
+  // Sort descending by total_quantity_sold, take top 10, add rank
+  return Object.values(totalsMap)
+    .sort((a, b) => b.total_quantity_sold - a.total_quantity_sold)
+    .slice(0, 10)
+    .map((item, idx) => ({ rank: idx + 1, ...item }));
+}


### PR DESCRIPTION
### What changed
* Added `getProductPriceReport()` (REP_001) to `src/services/reportService.js` to fetch current prices for all ACTIVE products.
* Added `getTopSellingReport()` (REP_002) to `src/services/reportService.js` to fetch the top 10 products ranked by total quantity sold.

### Why it was needed
This fulfills the M1 backend deliverables for the Sprint 3 Reports module. 

**Note on Technical Debt:** The initial plan was to query the `current_product_price` and `top_selling_products` SQL views. However, the current DB views are missing required UI columns (`description` and `unit`). To unblock the frontend (M2) and hit our sprint deadline, these service functions currently bypass the views and perform client-side joins/aggregations using the raw `product`, `pricehist`, and `salesdetail` tables. This works perfectly for our current dataset, but should be refactored to use updated SQL views in the future for better performance at scale.

### How to test it
1. Pull this branch and run the app locally.
2. Log in with any account (USER, ADMIN, or SUPERADMIN).
3. Navigate to the `/reports` route or run the temporary `useEffect` test block in `App.jsx`.
4. **REP_001 Check:** Verify the console outputs all ACTIVE products, correctly mapping the latest `effdate` and including the `description` and `unit` strings.
5. **REP_002 Check:** Verify the console outputs an array of exactly 10 items, sorted by `total_quantity_sold` in descending order.