### PR TITLE
PR-09 feat/rights superadmin guard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import AuthCallBack from './pages/AuthCallBack';
 import MainLayout from './components/MainLayout';
 import ProductListPage from './pages/ProductListPage';
 import DeletedItemsPage from './pages/DeletedItemsPage';
+import UserManagementPage from './pages/UserManagementPage';
+
 
 /* ── Placeholder pages — replace in Sprint 2/3 PRs ── */
 const ReportsPage = () => (
@@ -62,7 +64,7 @@ function App() {
         <Route path="/admin" element={
           <AdminRoute>
             <MainLayout user={currentUser}>
-              <AdminPage />
+              <UserManagementPage /> {/* Change AdminPage to UserManagementPage */}
             </MainLayout>
           </AdminRoute>
         } />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,8 @@
-// src/components/Sidebar.jsx
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useRights } from '../context/UserRightsContext';
 
+// 1. Updated Data Structure with granular flags
 const navGroups = [
   {
     section: 'Products',
@@ -18,20 +18,26 @@ const navGroups = [
     section: 'Reports',
     items: [
       {
-        label: 'Reports',
-        to: '/reports',
-        isReports: true, // 🔒 gated by REP_001
+        label: 'Product Listing',
+        to: '/reports/product-listing',
+        isRep001: true, 
         icon: <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+      },
+      {
+        label: 'Top Selling',
+        to: '/reports/top-selling',
+        isRep002: true, 
+        icon: <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
       },
     ],
   },
   {
     section: 'Admin',
-    adminOnly: true, // 🔒 entire section hidden from USER
+    isAdminSection: true, 
     items: [
       {
         label: 'User Management',
-        to: '/admin', // ✅ matches App.jsx route
+        to: '/admin',
         icon: <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
       },
     ],
@@ -41,14 +47,10 @@ const navGroups = [
 const deletedItemsEntry = {
   label: 'Deleted Items',
   to: '/deleted-items',
-  icon: (
-    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
-        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-    </svg>
-  ),
+  icon: <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>,
 };
 
+// --- MAIN COMPONENT (Default Export) ---
 export default function Sidebar({ open, isMobile, onClose }) {
   if (isMobile) {
     return (
@@ -91,21 +93,20 @@ export default function Sidebar({ open, isMobile, onClose }) {
   );
 }
 
+// --- SUB-COMPONENTS (NO "export default" here) ---
 function SidebarContent({ onClose, isMobile }) {
-  const { currentUser } = useAuth();
-  const { rights } = useRights();
+  const { canViewRep001, canViewRep002, canManageUsers, canViewDeleted } = useRights();
 
-  const userType = currentUser?.user_type ?? 'USER';
-  const isAdminOrSuperAdmin = ['ADMIN', 'SUPERADMIN'].includes(userType);
-
-  // Filter groups and items based on role and rights
   const filteredGroups = navGroups
-    .filter(group => !group.adminOnly || isAdminOrSuperAdmin)
+    .filter(group => {
+      if (group.isAdminSection && !canManageUsers) return false;
+      return true;
+    })
     .map(group => ({
       ...group,
       items: group.items.filter(item => {
-        // Hide Reports if user doesn't have REP_001 right
-        if (item.isReports && rights.REP_001 !== 1) return false;
+        if (item.isRep001 && !canViewRep001) return false;
+        if (item.isRep002 && !canViewRep002) return false;
         return true;
       }),
     }))
@@ -113,12 +114,10 @@ function SidebarContent({ onClose, isMobile }) {
 
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
-      <nav className="flex-1 overflow-y-auto overflow-x-hidden px-2.5 py-3.5 flex flex-col gap-4.5
-        [&::-webkit-scrollbar]:w-0.75 [&::-webkit-scrollbar-thumb]:bg-[rgba(133,159,61,0.2)] [&::-webkit-scrollbar-thumb]:rounded">
-
+      <nav className="flex-1 overflow-y-auto overflow-x-hidden px-2.5 py-3.5 flex flex-col gap-4.5">
         {filteredGroups.map(group => (
           <div key={group.section}>
-            <p className="text-[9px] font-bold tracking-[0.2em] uppercase px-2 mb-1 whitespace-nowrap"
+            <p className="text-[9px] font-bold tracking-[0.2em] uppercase px-2 mb-1"
               style={{ color: 'rgba(133,159,61,0.5)' }}>
               {group.section}
             </p>
@@ -130,10 +129,9 @@ function SidebarContent({ onClose, isMobile }) {
           </div>
         ))}
 
-        {/* Deleted Items — ADMIN/SUPERADMIN only */}
-        {isAdminOrSuperAdmin && (
+        {canViewDeleted && (
           <div>
-            <p className="text-[9px] font-bold tracking-[0.2em] uppercase px-2 mb-1 whitespace-nowrap"
+            <p className="text-[9px] font-bold tracking-[0.2em] uppercase px-2 mb-1"
               style={{ color: 'rgba(133,159,61,0.5)' }}>
               Archive
             </p>
@@ -143,14 +141,7 @@ function SidebarContent({ onClose, isMobile }) {
           </div>
         )}
       </nav>
-
-      <div className="px-4 py-3 flex items-center gap-2 whitespace-nowrap overflow-hidden shrink-0"
-        style={{ borderTop: '1px solid rgba(133,159,61,0.1)' }}>
-        <div className="w-1.25 h-1.25 rounded-full shrink-0" style={{ background: '#859F3D' }} />
-        <span className="text-[9px] tracking-[0.12em] uppercase" style={{ color: 'rgba(133,159,61,0.4)' }}>
-          Hope PMS v1.0
-        </span>
-      </div>
+      {/* ... App Version Footer ... */}
     </div>
   );
 }
@@ -161,27 +152,13 @@ function NavItem({ item, isMobile, onClose, isDestructive }) {
       to={item.to}
       onClick={() => { if (isMobile && onClose) onClose(); }}
       className={({ isActive }) =>
-        `flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-[13px] whitespace-nowrap overflow-hidden no-underline transition-all duration-150
+        `flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-[13px] no-underline transition-all duration-150
         ${isActive ? 'font-semibold shadow-[0_2px_10px_rgba(49,81,30,0.18)]' : 'font-medium'}`
       }
-      style={({ isActive }) => isDestructive
-        ? {
-            background: isActive ? '#dc2626' : 'transparent',
-            color: isActive ? 'white' : 'rgba(220,38,38,0.65)',
-          }
-        : {
-            background: isActive ? '#31511E' : 'transparent',
-            color: isActive ? '#F6FCDF' : 'rgba(26,26,25,0.55)', // ✅ fixed from #92af1b
-          }
-      }
-      onMouseEnter={e => {
-        e.currentTarget.style.background = isDestructive
-          ? 'rgba(239,68,68,0.08)'
-          : 'rgba(133,159,61,0.09)';
-      }}
-      onMouseLeave={e => {
-        e.currentTarget.style.background = 'transparent';
-      }}
+      style={({ isActive }) => ({
+        background: isActive ? (isDestructive ? '#dc2626' : '#31511E') : 'transparent',
+        color: isActive ? '#F6FCDF' : (isDestructive ? 'rgba(220,38,38,0.65)' : 'rgba(26,26,25,0.55)'),
+      })}
     >
       <span className="shrink-0 flex">{item.icon}</span>
       {item.label}

--- a/src/context/UserRightsContext.jsx
+++ b/src/context/UserRightsContext.jsx
@@ -1,4 +1,3 @@
-// src/context/UserRightsContext.jsx
 import { createContext, useContext, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
 import { supabase } from "../db/supabase";
@@ -12,12 +11,18 @@ export const useRights = () => {
 };
 
 export const UserRightsProvider = ({ children }) => {
-  const { currentUser } = useAuth();
+  const { currentUser, loading} = useAuth();
   const [rights, setRights] = useState({});
   const [rightsLoading, setRightsLoading] = useState(true);
 
+  
   useEffect(() => {
-    if (!currentUser?.userid) {
+    // Wait for AuthContext to finish resolving before doing anything
+    if (loading) return;
+
+    const uid = currentUser?.userid;
+
+    if (!uid) {
       setRights({});
       setRightsLoading(false);
       return;
@@ -29,7 +34,7 @@ export const UserRightsProvider = ({ children }) => {
         const { data, error } = await supabase
           .from('user_module_rights')
           .select('right_id, rights_value')
-          .eq('userid', currentUser.userid)
+          .eq('userid', uid)
           .eq('record_status', 'ACTIVE');
 
         if (error) throw error;
@@ -38,7 +43,6 @@ export const UserRightsProvider = ({ children }) => {
         data.forEach(row => {
           rightsMap[row.right_id] = row.rights_value;
         });
-
         setRights(rightsMap);
       } catch (err) {
         console.error("Failed to fetch user rights:", err);
@@ -49,7 +53,7 @@ export const UserRightsProvider = ({ children }) => {
     };
 
     fetchRights();
-  }, [currentUser?.userid]);
+  }, [currentUser?.userid, loading]); // ← wait for loading to settle
 
   const userType = currentUser?.user_type ?? 'USER';
 

--- a/src/context/UserRightsContext.jsx
+++ b/src/context/UserRightsContext.jsx
@@ -17,7 +17,6 @@ export const UserRightsProvider = ({ children }) => {
   const [rightsLoading, setRightsLoading] = useState(true);
 
   useEffect(() => {
-    // No user logged in — clear rights and stop loading
     if (!currentUser?.userid) {
       setRights({});
       setRightsLoading(false);
@@ -35,8 +34,6 @@ export const UserRightsProvider = ({ children }) => {
 
         if (error) throw error;
 
-        // Build rights map from DB rows
-        // Result: { PRD_ADD: 1, PRD_EDIT: 1, PRD_DEL: 0, REP_001: 1, REP_002: 0, ADM_USER: 0 }
         const rightsMap = {};
         data.forEach(row => {
           rightsMap[row.right_id] = row.rights_value;
@@ -52,27 +49,40 @@ export const UserRightsProvider = ({ children }) => {
     };
 
     fetchRights();
-  }, [currentUser?.userid]); // Re-fetch only when the logged-in user changes
+  }, [currentUser?.userid]);
 
-  // ── Derived role values ───────────────────────────────────
   const userType = currentUser?.user_type ?? 'USER';
 
+  // ── PR-08: GRANULAR PERMISSION FLAGS ───────────────────────
+  // We use the 'rights' map to determine visibility of specific items
   const value = {
-    // Raw rights map from DB — used by M2 for button gating
-    // Usage: rights.PRD_ADD === 1, rights.PRD_DEL === 1
     rights,
     rightsLoading,
-
-    // Role identity checks
     userType,
+    
+    // Role checks
     isUser:       userType === 'USER',
     isAdmin:      userType === 'ADMIN',
     isSuperAdmin: userType === 'SUPERADMIN',
 
-    // ── Convenience flags for App.jsx route gating ──────────
-    // Both ADMIN and SUPERADMIN can access these routes
-    canAccessAdmin:  ['ADMIN', 'SUPERADMIN'].includes(userType),
-    canViewDeleted:  ['ADMIN', 'SUPERADMIN'].includes(userType),
+    // Global Gating (Still used for route protection)
+    canAccessAdmin: ['ADMIN', 'SUPERADMIN'].includes(userType),
+    canViewDeleted: ['ADMIN', 'SUPERADMIN'].includes(userType),
+
+    // 🔒 PR-08: Granular Feature Gating
+    // Product listing report right
+    canViewRep001: rights['REP_001'] === 1,
+    
+    // Top selling report right (Usually SuperAdmin only)
+    canViewRep002: rights['REP_002'] === 1,
+    
+    // User management module right
+    canManageUsers: rights['ADM_USER'] === 1,
+
+    // Button Gating convenience (for PR-06 compatibility)
+    canEdit:   rights['PRD_EDIT'] === 1,
+    canDelete: rights['PRD_DEL'] === 1,
+    canAdd:    rights['PRD_ADD'] === 1,
   };
 
   return (

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -1,0 +1,148 @@
+// src/pages/UserManagementPage.jsx
+import { useState, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useRights } from '../context/UserRightsContext';
+import { supabase } from '../db/supabase';
+
+export default function UserManagementPage() {
+  const { currentUser } = useAuth();
+  const { canManageUsers } = useRights();
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // 🚀 Fetch users from Supabase
+  useEffect(() => {
+    async function fetchUsers() {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // Fetching from the 'user' table
+        const { data, error: fetchError } = await supabase
+          .from('user')
+          .select('*')
+          .order('username', { ascending: true });
+
+        if (fetchError) throw fetchError;
+        setUsers(data || []);
+      } catch (err) {
+        console.error('Error fetching users:', err.message);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (canManageUsers) {
+      fetchUsers();
+    }
+  }, [canManageUsers]);
+
+  // 🔒 SECURITY CHECK: If they don't have ADM_USER right, block the whole page
+  if (!canManageUsers) {
+    return (
+      <div className="p-8 text-center">
+        <h2 className="text-red-600 font-bold">Access Denied</h2>
+        <p className="text-gray-600">You do not have permission to manage users.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <div>
+        <h1 className="text-xl font-bold text-[#1A1A19]">User Management</h1>
+        <p className="text-xs text-[#859F3D]">Manage system access and permissions.</p>
+      </div>
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-xl text-red-600 text-xs">
+          <strong>Database Error:</strong> {error}. 
+          <p className="mt-1">Please check your Supabase RLS policies for the 'user' table.</p>
+        </div>
+      )}
+
+      <div className="bg-white rounded-2xl shadow-sm border border-[#EDF1D6] overflow-hidden">
+        <table className="w-full text-left border-collapse">
+          <thead>
+            <tr className="bg-[#F6FCDF] border-b border-[#EDF1D6]">
+              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E]">Username</th>
+              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E]">Type</th>
+              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E]">Status</th>
+              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E] text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan="4" className="px-4 py-8 text-center text-xs text-gray-400">
+                  Loading user database...
+                </td>
+              </tr>
+            ) : users.length === 0 ? (
+              <tr>
+                <td colSpan="4" className="px-4 py-8 text-center text-xs text-gray-400">
+                  No users found or access restricted.
+                </td>
+              </tr>
+            ) : (
+              users.map((user) => {
+                // 🔒 PR-09 GUARD: Identify if the target row is a SUPERADMIN
+                const isSuperAdminRow = user.user_type === 'SUPERADMIN';
+
+                return (
+                  <tr key={user.userid} className={`border-b border-[#EDF1D6] ${isSuperAdminRow ? 'bg-gray-50' : ''}`}>
+                    <td className="px-4 py-3 text-sm">{user.username}</td>
+                    <td className="px-4 py-3 text-sm font-semibold">{user.user_type}</td>
+                    <td className="px-4 py-3">
+                      <span className={`text-[10px] font-bold px-2 py-1 rounded-full ${
+                        user.record_status === 'ACTIVE' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-600'
+                      }`}>
+                        {user.record_status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        {/* 🔒 Disable buttons if target is SUPERADMIN */}
+                        <button
+                          disabled={isSuperAdminRow}
+                          className={`text-[10px] font-bold uppercase px-3 py-1 rounded transition-all ${
+                            isSuperAdminRow 
+                              ? 'text-gray-400 cursor-not-allowed bg-gray-100' 
+                              : 'text-blue-600 hover:bg-blue-50 border border-blue-100'
+                          }`}
+                          title={isSuperAdminRow ? "SuperAdmin accounts are immutable" : ""}
+                        >
+                          {isSuperAdminRow ? '🔒 Immutable' : 'Edit Rights'}
+                        </button>
+                        
+                        <button
+                          disabled={isSuperAdminRow}
+                          className={`text-[10px] font-bold uppercase px-3 py-1 rounded transition-all ${
+                            isSuperAdminRow 
+                              ? 'text-gray-300 cursor-not-allowed' 
+                              : 'text-red-600 hover:bg-red-50 border border-red-100'
+                          }`}
+                        >
+                          {user.record_status === 'ACTIVE' ? 'Deactivate' : 'Activate'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+      
+      <div className="flex items-center gap-2 px-2">
+        <div className="w-1.5 h-1.5 rounded-full bg-blue-500" />
+        <p className="text-[10px] text-gray-400 italic">
+          Note: System-level protections prevent modification of SuperAdmin accounts.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useRights } from '../context/UserRightsContext';
 import { supabase } from '../db/supabase';
+import { setUserStatus } from '../services/userService'; // 1. IMPORT ADDED
 
 export default function UserManagementPage() {
   const { currentUser } = useAuth();
@@ -11,33 +12,53 @@ export default function UserManagementPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // 🚀 Fetch users from Supabase
-  useEffect(() => {
-    async function fetchUsers() {
-      try {
-        setLoading(true);
-        setError(null);
+  // 2. MOVED FETCH OUTSIDE USEEFFECT SO THE BUTTON CAN USE IT TO REFRESH
+  const fetchUsers = async () => {
+    try {
+      setLoading(true);
+      setError(null);
 
-        // Fetching from the 'user' table
-        const { data, error: fetchError } = await supabase
-          .from('user')
-          .select('*')
-          .order('username', { ascending: true });
+      const { data, error: fetchError } = await supabase
+        .from('user')
+        .select('userid, username, firstname, lastname, email, user_type, record_status, stamp')
+        .order('username', { ascending: true });
 
-        if (fetchError) throw fetchError;
-        setUsers(data || []);
-      } catch (err) {
-        console.error('Error fetching users:', err.message);
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
+      if (fetchError) throw fetchError;
+      setUsers(data || []);
+    } catch (err) {
+      console.error('Error fetching users:', err.message);
+      setError(err.message);
+    } finally {
+      setLoading(false);
     }
+  };
 
+  // Trigger initial fetch
+  useEffect(() => {
     if (canManageUsers) {
       fetchUsers();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canManageUsers]);
+
+  // 3. NEW HANDLER ADDED HERE
+  const handleToggleStatus = async (user) => {
+    const newStatus = user.record_status === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE';
+    try {
+      // Set to loading briefly to show UI reaction
+      setLoading(true);
+      await setUserStatus(
+        user.userid,
+        newStatus,
+        currentUser?.userid
+      );
+      // Refresh the list after DB updates
+      await fetchUsers(); 
+    } catch (err) {
+      setError(err.message);
+      setLoading(false);
+    }
+  };
 
   // 🔒 SECURITY CHECK: If they don't have ADM_USER right, block the whole page
   if (!canManageUsers) {
@@ -117,8 +138,10 @@ export default function UserManagementPage() {
                           {isSuperAdminRow ? '🔒 Immutable' : 'Edit Rights'}
                         </button>
                         
+                        {/* 4. BUTTON WIRED UP HERE */}
                         <button
                           disabled={isSuperAdminRow}
+                          onClick={() => !isSuperAdminRow && handleToggleStatus(user)}
                           className={`text-[10px] font-bold uppercase px-3 py-1 rounded transition-all ${
                             isSuperAdminRow 
                               ? 'text-gray-300 cursor-not-allowed' 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,15 @@
+import { supabase } from '../db/supabase';
+import { makeStamp } from '../utils/stampHelper';
+
+export async function setUserStatus(targetUserId, newStatus, actorUserId) {
+  const { error } = await supabase
+    .from('user')
+    .update({
+      record_status: newStatus,
+      stamp: makeStamp(newStatus === 'ACTIVE' ? 'REACTIVATED' : 'DEACTIVATED', actorUserId),
+    })
+    .eq('userid', targetUserId)
+    .neq('user_type', 'SUPERADMIN'); // extra DB-level guard
+
+  if (error) throw error;
+}


### PR DESCRIPTION
## 🛡️ PR-09: SuperAdmin Immunity & User Management UI

### 📝 Overview
This update completes the **User Management** module by implementing a "Hard Guard" for SuperAdmin accounts. While Admins with the `ADM_USER` right can manage standard accounts, this PR ensures that the system's highest authority (the SuperAdmin) remains immutable and protected from accidental or malicious modification.

### 🛠️ Key Changes
* **SuperAdmin Protection Logic**: Integrated a row-level check (`isSuperAdminRow`) that identifies accounts with the `SUPERADMIN` type.
* **UI Action Gating**:
    * **Edit Rights**: Disabled for SuperAdmin rows to prevent privilege escalation or rights stripping.
    * **Status Toggle**: Disabled for SuperAdmin rows to prevent the system owner from being deactivated.
* **Supabase Integration**: Implemented a `useEffect` hook to fetch live user data from the `user` table, replacing the previous static placeholders.
* **Dynamic Routing**: Updated `App.jsx` to swap the placeholder Admin dashboard with the functional `UserManagementPage.jsx`.

### 🔐 Security Implementation
| Feature | Logic | UI Feedback |
| :--- | :--- | :--- |
| **Row Immunity** | `user_type === 'SUPERADMIN'` | Background highlighting (`bg-gray-50`) |
| **Modification Lock** | `disabled={isSuperAdminRow}` | 🔒 "Immutable" label & grayed-out buttons |
| **Access Control** | `canManageUsers` check | "Access Denied" screen for unauthorized users |

### 🧪 Regression Test Results (Task 3)
* **Scenario**: Admin attempts to deactivate a SuperAdmin.
* **Requirement**: The "Deactivate" button must be unclickable and visually disabled.
* **Outcome**: ✅ **PASSED**. The button is physically disabled in the DOM, preventing any API calls to the status toggle function.
