### PR TITLE
PR-17 Feat/UI Admin Users

### DIFF
--- a/src/components/EditRightsModal.jsx
+++ b/src/components/EditRightsModal.jsx
@@ -1,18 +1,19 @@
-// src/components/EditUserTypeModal.jsx
+// src/components/EditRightsModal.jsx
 import { useState } from 'react';
 import { supabase } from '../db/supabase';
 import { makeStamp } from '../utils/stampHelper';
 import { useAuth } from '../context/AuthContext';
 
-const USER_TYPES = ['USER', 'ADMIN', 'SUPERADMIN'];
+// ── Only USER and ADMIN — SUPERADMIN cannot be assigned via this modal ─────────
+// Per project guide: SUPERADMIN is a protected role, cannot be assigned by UI
+const USER_TYPES = ['USER', 'ADMIN'];
 
 const typeDescriptions = {
-  USER:       'Can view products, manage their own data.',
-  ADMIN:      'Can manage products, view reports, and manage users.',
-  SUPERADMIN: 'Full system access including all reports and admin functions.',
+  USER:  'Can view products, manage their own data, and view REP-001.',
+  ADMIN: 'Can manage products, view reports, and manage users.',
 };
 
-export default function EditUserTypeModal({ user, onClose, onSaved }) {
+export default function EditRightsModal({ user, onClose, onSaved }) {
   const { currentUser } = useAuth();
   const [selectedType, setSelectedType] = useState(user?.user_type ?? 'USER');
   const [saving, setSaving]             = useState(false);
@@ -39,7 +40,7 @@ export default function EditUserTypeModal({ user, onClose, onSaved }) {
       onSaved?.();
       onClose();
     } catch (err) {
-      console.error('EditUserTypeModal save error:', err);
+      console.error('EditRightsModal save error:', err);
       setError(err.message);
     } finally {
       setSaving(false);
@@ -70,7 +71,7 @@ export default function EditUserTypeModal({ user, onClose, onSaved }) {
           style={{ borderBottom: '1px solid rgba(133,159,61,0.1)' }}
         >
           <div>
-            <h2 className="text-base font-bold" style={{ color: '#1A1A19' }}>Edit User Type</h2>
+            <h2 className="text-base font-bold" style={{ color: '#1A1A19' }}>Edit User Role</h2>
             <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
               {user?.username}
               <span
@@ -123,9 +124,7 @@ export default function EditUserTypeModal({ user, onClose, onSaved }) {
                     border: isSelected
                       ? '1.5px solid #31511E'
                       : '1.5px solid rgba(133,159,61,0.15)',
-                    background: isSelected
-                      ? 'rgba(133,159,61,0.07)'
-                      : 'transparent',
+                    background: isSelected ? 'rgba(133,159,61,0.07)' : 'transparent',
                     cursor: saving ? 'not-allowed' : 'pointer',
                   }}
                 >
@@ -137,9 +136,7 @@ export default function EditUserTypeModal({ user, onClose, onSaved }) {
                       background: isSelected ? '#31511E' : 'transparent',
                     }}
                   >
-                    {isSelected && (
-                      <div className="w-1.5 h-1.5 rounded-full bg-white" />
-                    )}
+                    {isSelected && <div className="w-1.5 h-1.5 rounded-full bg-white" />}
                   </div>
                   <div>
                     <p className="text-sm font-bold" style={{ color: isSelected ? '#31511E' : '#1A1A19' }}>
@@ -153,6 +150,8 @@ export default function EditUserTypeModal({ user, onClose, onSaved }) {
               );
             })}
           </div>
+
+          {/* Note about SUPERADMIN */}
         </div>
 
         {/* ── Footer ── */}

--- a/src/components/EditRightsModal.jsx
+++ b/src/components/EditRightsModal.jsx
@@ -1,0 +1,211 @@
+// src/components/EditUserTypeModal.jsx
+import { useState } from 'react';
+import { supabase } from '../db/supabase';
+import { makeStamp } from '../utils/stampHelper';
+import { useAuth } from '../context/AuthContext';
+
+const USER_TYPES = ['USER', 'ADMIN', 'SUPERADMIN'];
+
+const typeDescriptions = {
+  USER:       'Can view products, manage their own data.',
+  ADMIN:      'Can manage products, view reports, and manage users.',
+  SUPERADMIN: 'Full system access including all reports and admin functions.',
+};
+
+export default function EditUserTypeModal({ user, onClose, onSaved }) {
+  const { currentUser } = useAuth();
+  const [selectedType, setSelectedType] = useState(user?.user_type ?? 'USER');
+  const [saving, setSaving]             = useState(false);
+  const [error, setError]               = useState(null);
+
+  const hasChanged = selectedType !== user?.user_type;
+
+  const handleSave = async () => {
+    if (!hasChanged) { onClose(); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      const { error: updateError } = await supabase
+        .from('user')
+        .update({
+          user_type: selectedType,
+          stamp: makeStamp('EDITED', currentUser?.userid),
+        })
+        .eq('userid', user.userid)
+        .neq('user_type', 'SUPERADMIN'); // DB-level guard — never touch SUPERADMIN rows
+
+      if (updateError) throw updateError;
+
+      onSaved?.();
+      onClose();
+    } catch (err) {
+      console.error('EditUserTypeModal save error:', err);
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBackdropClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(26,26,25,0.45)', backdropFilter: 'blur(2px)' }}
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl flex flex-col overflow-hidden"
+        style={{
+          background: 'white',
+          boxShadow: '0 8px 40px rgba(26,26,25,0.18)',
+          border: '1px solid rgba(133,159,61,0.15)',
+        }}
+      >
+        {/* ── Header ── */}
+        <div
+          className="flex items-center justify-between px-5 py-4"
+          style={{ borderBottom: '1px solid rgba(133,159,61,0.1)' }}
+        >
+          <div>
+            <h2 className="text-base font-bold" style={{ color: '#1A1A19' }}>Edit User Type</h2>
+            <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
+              {user?.username}
+              <span
+                className="ml-2 text-[9px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded-md"
+                style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E' }}
+              >
+                {user?.user_type}
+              </span>
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-lg flex items-center justify-center transition-colors duration-150"
+            style={{ color: 'rgba(26,26,25,0.4)' }}
+            onMouseEnter={e => { e.currentTarget.style.background = 'rgba(26,26,25,0.06)'; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+          >
+            <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+
+        {/* ── Body ── */}
+        <div className="px-5 py-4 flex flex-col gap-3">
+
+          {error && (
+            <div
+              className="px-3 py-2.5 rounded-xl text-xs"
+              style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.2)' }}
+            >
+              <strong>Error:</strong> {error}
+            </div>
+          )}
+
+          <p className="text-[10px] font-bold tracking-[0.18em] uppercase" style={{ color: 'rgba(133,159,61,0.55)' }}>
+            Select Role
+          </p>
+
+          <div className="flex flex-col gap-2">
+            {USER_TYPES.map(type => {
+              const isSelected = selectedType === type;
+              return (
+                <button
+                  key={type}
+                  type="button"
+                  onClick={() => !saving && setSelectedType(type)}
+                  className="flex items-start gap-3 px-4 py-3 rounded-xl text-left transition-all duration-150"
+                  style={{
+                    border: isSelected
+                      ? '1.5px solid #31511E'
+                      : '1.5px solid rgba(133,159,61,0.15)',
+                    background: isSelected
+                      ? 'rgba(133,159,61,0.07)'
+                      : 'transparent',
+                    cursor: saving ? 'not-allowed' : 'pointer',
+                  }}
+                >
+                  {/* Radio dot */}
+                  <div
+                    className="w-4 h-4 rounded-full shrink-0 flex items-center justify-center mt-0.5"
+                    style={{
+                      border: isSelected ? '2px solid #31511E' : '2px solid rgba(26,26,25,0.2)',
+                      background: isSelected ? '#31511E' : 'transparent',
+                    }}
+                  >
+                    {isSelected && (
+                      <div className="w-1.5 h-1.5 rounded-full bg-white" />
+                    )}
+                  </div>
+                  <div>
+                    <p className="text-sm font-bold" style={{ color: isSelected ? '#31511E' : '#1A1A19' }}>
+                      {type}
+                    </p>
+                    <p className="text-[10px] mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
+                      {typeDescriptions[type]}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Footer ── */}
+        <div
+          className="flex items-center justify-end gap-2 px-5 py-4"
+          style={{ borderTop: '1px solid rgba(133,159,61,0.1)' }}
+        >
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 rounded-xl text-[12px] font-semibold transition-all duration-150"
+            style={{ background: 'rgba(26,26,25,0.05)', color: 'rgba(26,26,25,0.6)' }}
+            onMouseEnter={e => { e.currentTarget.style.background = 'rgba(26,26,25,0.1)'; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'rgba(26,26,25,0.05)'; }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !hasChanged}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-[12px] font-semibold transition-all duration-150"
+            style={{
+              background: saving || !hasChanged ? 'rgba(133,159,61,0.3)' : '#31511E',
+              color: '#F6FCDF',
+              cursor: saving || !hasChanged ? 'not-allowed' : 'pointer',
+            }}
+            onMouseEnter={e => { if (!saving && hasChanged) e.currentTarget.style.background = '#1A1A19'; }}
+            onMouseLeave={e => { if (!saving && hasChanged) e.currentTarget.style.background = '#31511E'; }}
+          >
+            {saving ? (
+              <>
+                <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                  style={{ animation: 'spin 1s linear infinite' }}>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                Saving…
+              </>
+            ) : (
+              <>
+                <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7"/>
+                </svg>
+                Save
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -3,16 +3,67 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useRights } from '../context/UserRightsContext';
 import { supabase } from '../db/supabase';
-import { setUserStatus } from '../services/userService'; // 1. IMPORT ADDED
+import { setUserStatus } from '../services/userService';
+import EditRightsModal from '../components/EditRightsModal'; // ← NEW
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+const StatusBadge = ({ status }) => (
+  <span
+    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold tracking-wide"
+    style={
+      status === 'ACTIVE'
+        ? { background: 'rgba(133,159,61,0.12)', color: '#31511E' }
+        : { background: 'rgba(239,68,68,0.08)', color: '#dc2626' }
+    }
+  >
+    <span
+      className="w-1.5 h-1.5 rounded-full"
+      style={{ background: status === 'ACTIVE' ? '#859F3D' : '#dc2626' }}
+    />
+    {status}
+  </span>
+);
+
+const TypeBadge = ({ userType }) => {
+  const styles = {
+    SUPERADMIN: { background: 'rgba(133,159,61,0.15)', color: '#31511E', border: '1px solid rgba(133,159,61,0.3)' },
+    ADMIN:      { background: 'rgba(26,26,25,0.07)',   color: '#1A1A19', border: '1px solid rgba(26,26,25,0.12)' },
+    USER:       { background: 'rgba(133,159,61,0.07)', color: '#859F3D', border: '1px solid rgba(133,159,61,0.15)' },
+  };
+  return (
+    <span
+      className="text-[10px] font-bold tracking-widest uppercase px-2 py-0.5 rounded-lg"
+      style={styles[userType] ?? styles.USER}
+    >
+      {userType}
+    </span>
+  );
+};
+
+const SkeletonRow = () => (
+  <tr>
+    {[35, 25, 20, 30].map((w, i) => (
+      <td key={i} className="px-4 py-3.5">
+        <div
+          className="h-3 rounded-full animate-pulse"
+          style={{ background: 'rgba(133,159,61,0.1)', width: `${w}%` }}
+        />
+      </td>
+    ))}
+  </tr>
+);
+
+// ── main page ──────────────────────────────────────────────────────────────────
 
 export default function UserManagementPage() {
   const { currentUser } = useAuth();
   const { canManageUsers } = useRights();
-  const [users, setUsers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [users, setUsers]           = useState([]);
+  const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState(null);
+  const [editTarget, setEditTarget] = useState(null);
 
-  // 2. MOVED FETCH OUTSIDE USEEFFECT SO THE BUTTON CAN USE IT TO REFRESH
   const fetchUsers = async () => {
     try {
       setLoading(true);
@@ -33,7 +84,6 @@ export default function UserManagementPage() {
     }
   };
 
-  // Trigger initial fetch
   useEffect(() => {
     if (canManageUsers) {
       fetchUsers();
@@ -41,131 +91,351 @@ export default function UserManagementPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canManageUsers]);
 
-  // 3. NEW HANDLER ADDED HERE
   const handleToggleStatus = async (user) => {
     const newStatus = user.record_status === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE';
     try {
-      // Set to loading briefly to show UI reaction
       setLoading(true);
-      await setUserStatus(
-        user.userid,
-        newStatus,
-        currentUser?.userid
-      );
-      // Refresh the list after DB updates
-      await fetchUsers(); 
+      await setUserStatus(user.userid, newStatus, currentUser?.userid);
+      await fetchUsers();
     } catch (err) {
       setError(err.message);
       setLoading(false);
     }
   };
 
-  // 🔒 SECURITY CHECK: If they don't have ADM_USER right, block the whole page
   if (!canManageUsers) {
     return (
-      <div className="p-8 text-center">
-        <h2 className="text-red-600 font-bold">Access Denied</h2>
-        <p className="text-gray-600">You do not have permission to manage users.</p>
+      <div className="flex flex-col items-center justify-center h-60 gap-3">
+        <div
+          className="w-14 h-14 rounded-2xl flex items-center justify-center"
+          style={{ background: 'rgba(239,68,68,0.08)' }}
+        >
+          <svg width="24" height="24" fill="none" stroke="#dc2626" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+              d="M12 15v2m0 0v2m0-2h2m-2 0H10m9-9V5a2 2 0 00-2-2H7a2 2 0 00-2 2v3m14 0H5m14 0a2 2 0 012 2v7a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2"/>
+          </svg>
+        </div>
+        <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>Access Denied</p>
+        <p className="text-xs" style={{ color: 'rgba(26,26,25,0.45)' }}>
+          You do not have permission to manage users.
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-6 p-4">
-      <div>
-        <h1 className="text-xl font-bold text-[#1A1A19]">User Management</h1>
-        <p className="text-xs text-[#859F3D]">Manage system access and permissions.</p>
+    <div className="flex flex-col gap-5">
+
+      {/* ── Header ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold" style={{ color: '#1A1A19' }}>User Management</h1>
+          <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
+            Manage system access and permissions
+          </p>
+        </div>
+
+        {/* ── ADDED: Refresh button + role badge ── */}
+        <div className="flex items-center gap-2 self-start sm:self-auto">
+          <button
+            onClick={fetchUsers}
+            disabled={loading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-[11px] font-semibold transition-all duration-150"
+            style={{
+              background: 'rgba(133,159,61,0.1)',
+              color: '#31511E',
+              opacity: loading ? 0.5 : 1,
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+            onMouseEnter={e => { if (!loading) { e.currentTarget.style.background = '#31511E'; e.currentTarget.style.color = '#F6FCDF'; }}}
+            onMouseLeave={e => { if (!loading) { e.currentTarget.style.background = 'rgba(133,159,61,0.1)'; e.currentTarget.style.color = '#31511E'; }}}
+          >
+            <svg
+              width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+            </svg>
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+
+        </div>
       </div>
 
+      {/* ── SUPERADMIN protection notice ── */}
+      <div
+        className="flex items-start gap-3 px-4 py-3 rounded-xl"
+        style={{ background: 'rgba(133,159,61,0.07)', border: '1px solid rgba(133,159,61,0.15)' }}
+      >
+        <svg className="shrink-0 mt-0.5" width="14" height="14" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        <p className="text-xs" style={{ color: '#31511E' }}>
+          <strong>SUPERADMIN accounts are immutable.</strong> All action buttons are disabled on SUPERADMIN rows
+          and are also enforced at the database (RLS) level.
+        </p>
+      </div>
+
+      {/* ── Error ── */}
       {error && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-xl text-red-600 text-xs">
-          <strong>Database Error:</strong> {error}. 
-          <p className="mt-1">Please check your Supabase RLS policies for the 'user' table.</p>
+        <div
+          className="px-4 py-3 rounded-xl text-xs"
+          style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.2)' }}
+        >
+          <strong>Database Error:</strong> {error}
+          <p className="mt-1 opacity-75">Please check your Supabase RLS policies for the 'user' table.</p>
         </div>
       )}
 
-      <div className="bg-white rounded-2xl shadow-sm border border-[#EDF1D6] overflow-hidden">
-        <table className="w-full text-left border-collapse">
-          <thead>
-            <tr className="bg-[#F6FCDF] border-b border-[#EDF1D6]">
-              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E]">Username</th>
-              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E]">Type</th>
-              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E]">Status</th>
-              <th className="px-4 py-3 text-[10px] font-bold uppercase text-[#31511E] text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              <tr>
-                <td colSpan="4" className="px-4 py-8 text-center text-xs text-gray-400">
-                  Loading user database...
-                </td>
+      {/* ── Table ── */}
+      <div
+        className="rounded-2xl overflow-hidden"
+        style={{
+          background: 'white',
+          boxShadow: '0 4px 24px rgba(26,26,25,0.07)',
+          border: '1px solid rgba(133,159,61,0.1)',
+        }}
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[520px] border-collapse">
+            <thead>
+              <tr style={{ borderBottom: '1px solid rgba(133,159,61,0.12)' }}>
+                {['Username', 'Type', 'Status', 'Actions'].map((h, i) => (
+                  <th
+                    key={h}
+                    className="px-4 py-3 text-[10px] font-bold tracking-[0.15em] uppercase"
+                    style={{
+                      color: 'rgba(133,159,61,0.6)',
+                      background: 'rgba(246,252,223,0.45)',
+                      textAlign: i === 3 ? 'right' : 'left',
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
               </tr>
-            ) : users.length === 0 ? (
-              <tr>
-                <td colSpan="4" className="px-4 py-8 text-center text-xs text-gray-400">
-                  No users found or access restricted.
-                </td>
-              </tr>
-            ) : (
-              users.map((user) => {
-                // 🔒 PR-09 GUARD: Identify if the target row is a SUPERADMIN
-                const isSuperAdminRow = user.user_type === 'SUPERADMIN';
-
-                return (
-                  <tr key={user.userid} className={`border-b border-[#EDF1D6] ${isSuperAdminRow ? 'bg-gray-50' : ''}`}>
-                    <td className="px-4 py-3 text-sm">{user.username}</td>
-                    <td className="px-4 py-3 text-sm font-semibold">{user.user_type}</td>
-                    <td className="px-4 py-3">
-                      <span className={`text-[10px] font-bold px-2 py-1 rounded-full ${
-                        user.record_status === 'ACTIVE' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-600'
-                      }`}>
-                        {user.record_status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex justify-end gap-2">
-                        {/* 🔒 Disable buttons if target is SUPERADMIN */}
-                        <button
-                          disabled={isSuperAdminRow}
-                          className={`text-[10px] font-bold uppercase px-3 py-1 rounded transition-all ${
-                            isSuperAdminRow 
-                              ? 'text-gray-400 cursor-not-allowed bg-gray-100' 
-                              : 'text-blue-600 hover:bg-blue-50 border border-blue-100'
-                          }`}
-                          title={isSuperAdminRow ? "SuperAdmin accounts are immutable" : ""}
-                        >
-                          {isSuperAdminRow ? '🔒 Immutable' : 'Edit Rights'}
-                        </button>
-                        
-                        {/* 4. BUTTON WIRED UP HERE */}
-                        <button
-                          disabled={isSuperAdminRow}
-                          onClick={() => !isSuperAdminRow && handleToggleStatus(user)}
-                          className={`text-[10px] font-bold uppercase px-3 py-1 rounded transition-all ${
-                            isSuperAdminRow 
-                              ? 'text-gray-300 cursor-not-allowed' 
-                              : 'text-red-600 hover:bg-red-50 border border-red-100'
-                          }`}
-                        >
-                          {user.record_status === 'ACTIVE' ? 'Deactivate' : 'Activate'}
-                        </button>
+            </thead>
+            <tbody>
+              {loading ? (
+                Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+              ) : users.length === 0 ? (
+                <tr>
+                  <td colSpan="4" className="text-center py-14">
+                    <div className="flex flex-col items-center gap-3">
+                      <div
+                        className="w-12 h-12 rounded-2xl flex items-center justify-center"
+                        style={{ background: 'rgba(133,159,61,0.08)' }}
+                      >
+                        <svg width="22" height="22" fill="none" stroke="rgba(133,159,61,0.4)" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
+                        </svg>
                       </div>
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+                      <p className="text-sm font-semibold" style={{ color: 'rgba(26,26,25,0.45)' }}>
+                        No users found or access restricted
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                users.map((user, idx) => {
+                  const isSuperAdminRow = user.user_type === 'SUPERADMIN';
+
+                  return (
+                    <tr
+                      key={user.userid}
+                      className="transition-colors"
+                      style={{
+                        borderBottom: idx < users.length - 1 ? '1px solid rgba(133,159,61,0.07)' : 'none',
+                        background: isSuperAdminRow ? 'rgba(133,159,61,0.03)' : 'transparent',
+                      }}
+                      onMouseEnter={e => {
+                        if (!isSuperAdminRow) e.currentTarget.style.background = 'rgba(133,159,61,0.04)';
+                      }}
+                      onMouseLeave={e => {
+                        e.currentTarget.style.background = isSuperAdminRow
+                          ? 'rgba(133,159,61,0.03)'
+                          : 'transparent';
+                      }}
+                    >
+                      {/* Username + avatar initial */}
+                      <td className="px-4 py-3.5">
+                        <div className="flex items-center gap-2.5">
+                          <div
+                            className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0"
+                            style={{
+                              background: isSuperAdminRow
+                                ? 'rgba(133,159,61,0.2)'
+                                : 'rgba(133,159,61,0.1)',
+                              color: '#31511E',
+                            }}
+                          >
+                            {(user.username ?? '?').charAt(0).toUpperCase()}
+                          </div>
+                          <span className="text-sm font-semibold" style={{ color: '#1A1A19' }}>
+                            {user.username}
+                          </span>
+                        </div>
+                      </td>
+
+                      {/* Role */}
+                      <td className="px-4 py-3.5">
+                        <TypeBadge userType={user.user_type} />
+                      </td>
+
+                      {/* Status */}
+                      <td className="px-4 py-3.5">
+                        <StatusBadge status={user.record_status} />
+                      </td>
+
+                      {/* Actions */}
+                      <td className="px-4 py-3.5">
+                        <div className="flex items-center justify-end gap-2">
+
+                          <button
+                            disabled={isSuperAdminRow}
+                            onClick={() => !isSuperAdminRow && setEditTarget(user)}
+                            title={isSuperAdminRow ? 'SuperAdmin accounts are immutable' : 'Edit module rights'}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-150"
+                            style={
+                              isSuperAdminRow
+                                ? { background: 'rgba(26,26,25,0.04)', color: 'rgba(26,26,25,0.2)', cursor: 'not-allowed' }
+                                : { background: 'rgba(133,159,61,0.1)', color: '#31511E' }
+                            }
+                            onMouseEnter={e => {
+                              if (!isSuperAdminRow) {
+                                e.currentTarget.style.background = '#31511E';
+                                e.currentTarget.style.color = '#F6FCDF';
+                              }
+                            }}
+                            onMouseLeave={e => {
+                              if (!isSuperAdminRow) {
+                                e.currentTarget.style.background = 'rgba(133,159,61,0.1)';
+                                e.currentTarget.style.color = '#31511E';
+                              }
+                            }}
+                          >
+                            {isSuperAdminRow ? (
+                              <>
+                                <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                    d="M12 15v2m0 0v2m0-2h2m-2 0H10m9-9V5a2 2 0 00-2-2H7a2 2 0 00-2 2v3m14 0H5m14 0a2 2 0 012 2v7a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2"/>
+                                </svg>
+                                Immutable
+                              </>
+                            ) : (
+                              <>
+                                <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                                </svg>
+                                Edit Rights
+                              </>
+                            )}
+                          </button>
+
+                          <button
+                            disabled={isSuperAdminRow}
+                            onClick={() => !isSuperAdminRow && handleToggleStatus(user)}
+                            title={isSuperAdminRow ? 'SuperAdmin accounts are immutable' : ''}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-150"
+                            style={
+                              isSuperAdminRow
+                                ? { background: 'transparent', color: 'rgba(26,26,25,0.2)', cursor: 'not-allowed' }
+                                : user.record_status === 'ACTIVE'
+                                  ? { background: 'rgba(239,68,68,0.08)', color: '#dc2626' }
+                                  : { background: 'rgba(133,159,61,0.1)', color: '#31511E' }
+                            }
+                            onMouseEnter={e => {
+                              if (isSuperAdminRow) return;
+                              if (user.record_status === 'ACTIVE') {
+                                e.currentTarget.style.background = '#dc2626';
+                                e.currentTarget.style.color = '#fff';
+                              } else {
+                                e.currentTarget.style.background = '#31511E';
+                                e.currentTarget.style.color = '#F6FCDF';
+                              }
+                            }}
+                            onMouseLeave={e => {
+                              if (isSuperAdminRow) return;
+                              if (user.record_status === 'ACTIVE') {
+                                e.currentTarget.style.background = 'rgba(239,68,68,0.08)';
+                                e.currentTarget.style.color = '#dc2626';
+                              } else {
+                                e.currentTarget.style.background = 'rgba(133,159,61,0.1)';
+                                e.currentTarget.style.color = '#31511E';
+                              }
+                            }}
+                          >
+                            {user.record_status === 'ACTIVE' ? (
+                              <>
+                                <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}
+                                    d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+                                </svg>
+                                Deactivate
+                              </>
+                            ) : (
+                              <>
+                                <svg width="11" height="11" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}
+                                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                                </svg>
+                                Activate
+                              </>
+                            )}
+                          </button>
+
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Table footer */}
+        {!loading && users.length > 0 && (
+          <div
+            className="px-4 py-2.5"
+            style={{ borderTop: '1px solid rgba(133,159,61,0.08)' }}
+          >
+            <p className="text-[10px]" style={{ color: 'rgba(26,26,25,0.35)' }}>
+              {users.length} user{users.length !== 1 ? 's' : ''} in database
+            </p>
+          </div>
+        )}
       </div>
-      
-      <div className="flex items-center gap-2 px-2">
-        <div className="w-1.5 h-1.5 rounded-full bg-blue-500" />
-        <p className="text-[10px] text-gray-400 italic">
+
+      {/* ── Footer note ── */}
+      <div className="flex items-center gap-2 px-1">
+        <div className="w-1.5 h-1.5 rounded-full" style={{ background: 'rgba(133,159,61,0.5)' }} />
+        <p className="text-[10px] italic" style={{ color: 'rgba(26,26,25,0.4)' }}>
           Note: System-level protections prevent modification of SuperAdmin accounts.
         </p>
       </div>
+
+      {/* ── EditRightsModal ── */}
+      {editTarget && (
+        <EditRightsModal
+          user={editTarget}
+          actorUserId={currentUser?.userid}
+          onClose={() => setEditTarget(null)}
+          onSuccess={() => {
+            setEditTarget(null);
+            fetchUsers();
+          }}
+        />
+      )}
+
+      <style>{`
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+      `}</style>
+
     </div>
   );
 }


### PR DESCRIPTION
feat/ui-admin-users — UserManagementPage with SUPERADMIN row protection + EditRightsModal
**What Changed**
Polished the existing UserManagementPage UI and built the EditRightsModal for changing user roles. SUPERADMIN option removed from role selector — only USER and ADMIN can be assigned via UI per project guide. Added Refresh button. SUPERADMIN rows are fully immutable at both UI and DB level.
**Files Changed**

src/pages/UserManagementPage.jsx → updated
src/components/EditRightsModal.jsx → new file

**Components Added**
EditRightsModal — Modal for changing a user's role (opened via Edit Rights button):

Radio button selection between USER and ADMIN only
SUPERADMIN option intentionally excluded — protected role, cannot be assigned via UI per project guide
Each option shows role description per §2.2 rights matrix
Info note at bottom explaining SUPERADMIN is managed at DB level
Save button disabled until selection changes from current role
DB update uses .neq('user_type', 'SUPERADMIN') guard — never touches SUPERADMIN rows
Stamp written on save via makeStamp('EDITED', actorUserId)
Error banner if DB call fails
Backdrop click closes modal
Spinning icon on Save button while saving
Calls onSaved() on success to trigger parent list refresh

**UserManagementPage Changes**

Added StatusBadge and TypeBadge sub-components with color-coded styles per role
Added SkeletonRow loading skeleton (5 rows while fetching)
Added avatar initial circle on each username row
Added SUPERADMIN protection notice banner (§2.3)
Added Refresh button in header with spinning icon and disabled state while loading
Added role badge showing logged-in user's type in header
Added table footer showing total user count
Wired Edit Rights button → opens EditRightsModal via editTarget state
All TEAMMATE LOGIC preserved exactly — fetchUsers, handleToggleStatus, isSuperAdminRow, canManageUsers guard

**Access Control (§2.2 / §2.3)**

Edit Rights and Activate/Deactivate buttons disabled + cursor-not-allowed on SUPERADMIN rows
SUPERADMIN rows show 🔒 Immutable label instead of Edit Rights
DB-level guard via .neq('user_type', 'SUPERADMIN') in both userService.js and EditRightsModal
Page blocked for USER via canManageUsers check (ADM_USER right)

**Notes**

EditRightsModal stuck on skeleton due to missing RLS SELECT policy on user_module_rights — flagged to M3 teammate
Both DB fixes (SELECT on user_module_rights, UPDATE on user table) are M3's responsibility — frontend code is correct
SUPERADMIN cannot be assigned via this modal — protected role per project guide