### PR TITLE
PR-18 Feat/UI reports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,22 +11,8 @@ import MainLayout from './components/MainLayout';
 import ProductListPage from './pages/ProductListPage';
 import DeletedItemsPage from './pages/DeletedItemsPage';
 import UserManagementPage from './pages/UserManagementPage';
-
-
-/* ── Placeholder pages — replace in Sprint 2/3 PRs ── */
-const ReportsPage = () => (
-  <div className="p-4">
-    <h1 className="text-xl font-bold text-[#31511E] mb-1">Reports</h1>
-    <p className="text-xs text-[#859F3D]">View system reports here.</p>
-  </div>
-);
-
-const AdminPage = () => (
-  <div className="p-4">
-    <h1 className="text-xl font-bold text-[#31511E] mb-1">Admin Dashboard</h1>
-    <p className="text-xs text-[#859F3D]">Manage users and system settings.</p>
-  </div>
-);
+import ProductReportPage from './pages/ProductReportPage';   // REP_001
+import TopSellingPage from './pages/TopSellingPage';         // REP_002
 
 function App() {
   const { currentUser, loading } = useAuth();
@@ -52,10 +38,20 @@ function App() {
           </ProtectedRoute>
         } />
 
-        <Route path="/reports" element={
+        {/* REP_001 — Product Price Report (all authenticated roles) */}
+        <Route path="/reports/product-listing" element={
           <ProtectedRoute>
             <MainLayout user={currentUser}>
-              <ReportsPage />
+              <ProductReportPage />
+            </MainLayout>
+          </ProtectedRoute>
+        } />
+
+        {/* REP_002 — Top Selling Report (SUPERADMIN only — page self-guards via canViewRep002) */}
+        <Route path="/reports/top-selling" element={
+          <ProtectedRoute>
+            <MainLayout user={currentUser}>
+              <TopSellingPage />
             </MainLayout>
           </ProtectedRoute>
         } />
@@ -64,7 +60,7 @@ function App() {
         <Route path="/admin" element={
           <AdminRoute>
             <MainLayout user={currentUser}>
-              <UserManagementPage /> {/* Change AdminPage to UserManagementPage */}
+              <UserManagementPage />
             </MainLayout>
           </AdminRoute>
         } />

--- a/src/pages/ProductReportPage.jsx
+++ b/src/pages/ProductReportPage.jsx
@@ -17,6 +17,30 @@ const formatDate = (dateStr) => {
   return d.toLocaleDateString('en-PH', { year: 'numeric', month: 'short', day: 'numeric' });
 };
 
+// ── CSV Export Helper ──────────────────────────────────────────────────────────
+// Per project guide Sprint 3: ProductReportPage includes CSV export
+
+function exportToCSV(rows, search) {
+  const headers = ['Product Code', 'Description', 'Unit', 'Current Price', 'Effective Date'];
+
+  const csvRows = rows.map(r => [
+    r.prodcode      ?? '',
+    r.description   ?? '',
+    r.unit          ?? '',
+    r.current_price != null ? Number(r.current_price).toFixed(2) : '',
+    r.effective_date ?? '',
+  ].map(v => `"${String(v).replace(/"/g, '""')}"`).join(','));
+
+  const csv      = [headers.join(','), ...csvRows].join('\n');
+  const blob     = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url      = URL.createObjectURL(blob);
+  const link     = document.createElement('a');
+  link.href      = url;
+  link.download  = `product_report_${new Date().toISOString().slice(0, 10)}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
 // ── Sub-components ─────────────────────────────────────────────────────────────
 
 const SkeletonRow = () => (
@@ -63,10 +87,10 @@ const EmptyState = ({ search }) => (
 export default function ProductReportPage() {
   const { canViewRep001 } = useRights();
 
-  const [rows, setRows]         = useState([]);
-  const [loading, setLoading]   = useState(true);
-  const [error, setError]       = useState(null);
-  const [search, setSearch]     = useState('');
+  const [rows, setRows]             = useState([]);
+  const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState(null);
+  const [search, setSearch]         = useState('');
   const [sortConfig, setSortConfig] = useState({ key: 'prodcode', dir: 'asc' });
 
   const fetchReport = async () => {
@@ -100,7 +124,7 @@ export default function ProductReportPage() {
   const SortIcon = ({ colKey }) => {
     const isActive = sortConfig.key === colKey;
     return (
-      <span className="inline-flex flex-col ml-1 opacity-40" style={{ opacity: isActive ? 1 : 0.3 }}>
+      <span className="inline-flex flex-col ml-1" style={{ opacity: isActive ? 1 : 0.3 }}>
         <svg width="8" height="8" viewBox="0 0 8 8" fill={isActive && sortConfig.dir === 'asc' ? '#31511E' : '#859F3D'}>
           <path d="M4 1L7 5H1z"/>
         </svg>
@@ -160,7 +184,27 @@ export default function ProductReportPage() {
           </p>
         </div>
 
+        {/* ── Action buttons ── */}
         <div className="flex items-center gap-2 self-start sm:self-auto">
+
+          {/* CSV Export — only when data is available */}
+          {!loading && filtered.length > 0 && (
+            <button
+              onClick={() => exportToCSV(filtered, search)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-[11px] font-semibold transition-all duration-150"
+              style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E' }}
+              onMouseEnter={e => { e.currentTarget.style.background = '#31511E'; e.currentTarget.style.color = '#F6FCDF'; }}
+              onMouseLeave={e => { e.currentTarget.style.background = 'rgba(133,159,61,0.1)'; e.currentTarget.style.color = '#31511E'; }}
+              title="Export current view to CSV"
+            >
+              <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+              </svg>
+              Export CSV
+            </button>
+          )}
+
           {/* Refresh */}
           <button
             onClick={fetchReport}
@@ -294,10 +338,10 @@ export default function ProductReportPage() {
             <thead>
               <tr style={{ borderBottom: '1px solid rgba(133,159,61,0.1)' }}>
                 {[
-                  { label: 'Product Code', key: 'prodcode' },
-                  { label: 'Description',  key: 'description' },
-                  { label: 'Unit',         key: 'unit' },
-                  { label: 'Current Price',key: 'current_price' },
+                  { label: 'Product Code',  key: 'prodcode' },
+                  { label: 'Description',   key: 'description' },
+                  { label: 'Unit',          key: 'unit' },
+                  { label: 'Current Price', key: 'current_price' },
                   { label: 'Effective Date',key: 'effective_date' },
                 ].map(col => (
                   <th
@@ -327,7 +371,6 @@ export default function ProductReportPage() {
                       onMouseEnter={e => { e.currentTarget.style.background = 'rgba(133,159,61,0.03)'; }}
                       onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                     >
-                      {/* Product Code */}
                       <td className="px-4 py-3.5">
                         <span
                           className="font-mono text-xs font-bold px-2 py-0.5 rounded-lg"
@@ -336,13 +379,9 @@ export default function ProductReportPage() {
                           {row.prodcode}
                         </span>
                       </td>
-
-                      {/* Description */}
                       <td className="px-4 py-3.5">
                         <span className="text-sm" style={{ color: '#1A1A19' }}>{row.description}</span>
                       </td>
-
-                      {/* Unit */}
                       <td className="px-4 py-3.5">
                         <span
                           className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-md"
@@ -351,8 +390,6 @@ export default function ProductReportPage() {
                           {row.unit ?? '—'}
                         </span>
                       </td>
-
-                      {/* Price */}
                       <td className="px-4 py-3.5">
                         {row.current_price != null ? (
                           <span className="text-sm font-bold" style={{ color: '#31511E' }}>
@@ -362,8 +399,6 @@ export default function ProductReportPage() {
                           <span className="text-xs italic" style={{ color: 'rgba(26,26,25,0.3)' }}>No price</span>
                         )}
                       </td>
-
-                      {/* Effective Date */}
                       <td className="px-4 py-3.5">
                         <span className="text-xs" style={{ color: 'rgba(26,26,25,0.55)' }}>
                           {formatDate(row.effective_date)}

--- a/src/pages/ProductReportPage.jsx
+++ b/src/pages/ProductReportPage.jsx
@@ -1,0 +1,401 @@
+// src/pages/ProductReportPage.jsx
+// REP_001 — Product Price Report
+// Access: SUPERADMIN, ADMIN, USER (all authenticated roles with REP_001 right)
+
+import { useState, useEffect } from 'react';
+import { useRights } from '../context/UserRightsContext';
+import { getProductPriceReport } from '../services/reportService';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const formatPrice = (price) =>
+  price == null ? '—' : `₱${Number(price).toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return '—';
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-PH', { year: 'numeric', month: 'short', day: 'numeric' });
+};
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+const SkeletonRow = () => (
+  <tr>
+    {[20, 40, 15, 20, 25].map((w, i) => (
+      <td key={i} className="px-4 py-3.5">
+        <div
+          className="h-3 rounded-full animate-pulse"
+          style={{ background: 'rgba(133,159,61,0.1)', width: `${w}%` }}
+        />
+      </td>
+    ))}
+  </tr>
+);
+
+const EmptyState = ({ search }) => (
+  <tr>
+    <td colSpan={5} className="px-4 py-16 text-center">
+      <div className="flex flex-col items-center gap-3">
+        <div
+          className="w-12 h-12 rounded-2xl flex items-center justify-center"
+          style={{ background: 'rgba(133,159,61,0.08)' }}
+        >
+          <svg width="22" height="22" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+              d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+          </svg>
+        </div>
+        <div>
+          <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>
+            {search ? 'No results found' : 'No products found'}
+          </p>
+          <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.4)' }}>
+            {search ? `No products match "${search}"` : 'No active products with price data available.'}
+          </p>
+        </div>
+      </div>
+    </td>
+  </tr>
+);
+
+// ── Main Page ──────────────────────────────────────────────────────────────────
+
+export default function ProductReportPage() {
+  const { canViewRep001 } = useRights();
+
+  const [rows, setRows]         = useState([]);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(null);
+  const [search, setSearch]     = useState('');
+  const [sortConfig, setSortConfig] = useState({ key: 'prodcode', dir: 'asc' });
+
+  const fetchReport = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getProductPriceReport();
+      setRows(data);
+    } catch (err) {
+      console.error('ProductReportPage error:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (canViewRep001) fetchReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canViewRep001]);
+
+  // ── Sorting ──
+  const handleSort = (key) => {
+    setSortConfig(prev =>
+      prev.key === key
+        ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : { key, dir: 'asc' }
+    );
+  };
+
+  const SortIcon = ({ colKey }) => {
+    const isActive = sortConfig.key === colKey;
+    return (
+      <span className="inline-flex flex-col ml-1 opacity-40" style={{ opacity: isActive ? 1 : 0.3 }}>
+        <svg width="8" height="8" viewBox="0 0 8 8" fill={isActive && sortConfig.dir === 'asc' ? '#31511E' : '#859F3D'}>
+          <path d="M4 1L7 5H1z"/>
+        </svg>
+        <svg width="8" height="8" viewBox="0 0 8 8" fill={isActive && sortConfig.dir === 'desc' ? '#31511E' : '#859F3D'}>
+          <path d="M4 7L7 3H1z"/>
+        </svg>
+      </span>
+    );
+  };
+
+  // ── Filter + Sort ──
+  const filtered = rows
+    .filter(r =>
+      !search ||
+      r.prodcode.toLowerCase().includes(search.toLowerCase()) ||
+      r.description.toLowerCase().includes(search.toLowerCase()) ||
+      (r.unit ?? '').toLowerCase().includes(search.toLowerCase())
+    )
+    .sort((a, b) => {
+      const { key, dir } = sortConfig;
+      let aVal = a[key] ?? '';
+      let bVal = b[key] ?? '';
+      if (key === 'current_price') { aVal = Number(aVal) || 0; bVal = Number(bVal) || 0; }
+      if (aVal < bVal) return dir === 'asc' ? -1 : 1;
+      if (aVal > bVal) return dir === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+  // ── Access guard ──
+  if (!canViewRep001) {
+    return (
+      <div className="flex flex-col items-center justify-center h-60 gap-3">
+        <div className="w-14 h-14 rounded-2xl flex items-center justify-center"
+          style={{ background: 'rgba(239,68,68,0.08)' }}>
+          <svg width="24" height="24" fill="none" stroke="#dc2626" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+              d="M12 15v2m0 0v2m0-2h2m-2 0H10m9-9V5a2 2 0 00-2-2H7a2 2 0 00-2 2v3m14 0H5m14 0a2 2 0 012 2v7a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2"/>
+          </svg>
+        </div>
+        <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>Access Denied</p>
+        <p className="text-xs" style={{ color: 'rgba(26,26,25,0.45)' }}>
+          You do not have permission to view this report.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+
+      {/* ── Header ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold" style={{ color: '#1A1A19' }}>Product Price Report</h1>
+          <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
+            Current prices for all active products
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 self-start sm:self-auto">
+          {/* Refresh */}
+          <button
+            onClick={fetchReport}
+            disabled={loading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-[11px] font-semibold transition-all duration-150"
+            style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E', opacity: loading ? 0.5 : 1 }}
+            onMouseEnter={e => { if (!loading) { e.currentTarget.style.background = '#31511E'; e.currentTarget.style.color = '#F6FCDF'; }}}
+            onMouseLeave={e => { if (!loading) { e.currentTarget.style.background = 'rgba(133,159,61,0.1)'; e.currentTarget.style.color = '#31511E'; }}}
+          >
+            <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }}>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+            </svg>
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      {/* ── Error ── */}
+      {error && (
+        <div
+          className="px-4 py-3 rounded-xl text-xs"
+          style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.2)' }}
+        >
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {/* ── Stats bar ── */}
+      {!loading && rows.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {[
+            {
+              label: 'Active Products',
+              value: rows.length,
+              icon: (
+                <svg width="14" height="14" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+                    d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+                </svg>
+              ),
+            },
+            {
+              label: 'With Price',
+              value: rows.filter(r => r.current_price != null).length,
+              icon: (
+                <svg width="14" height="14" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+                    d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              ),
+            },
+            {
+              label: 'No Price Set',
+              value: rows.filter(r => r.current_price == null).length,
+              icon: (
+                <svg width="14" height="14" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+                    d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              ),
+            },
+          ].map(stat => (
+            <div
+              key={stat.label}
+              className="flex items-center gap-3 px-4 py-3 rounded-xl"
+              style={{ background: 'white', border: '1px solid rgba(133,159,61,0.1)', boxShadow: '0 1px 4px rgba(26,26,25,0.04)' }}
+            >
+              <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+                style={{ background: 'rgba(133,159,61,0.08)' }}>
+                {stat.icon}
+              </div>
+              <div>
+                <p className="text-lg font-bold leading-none" style={{ color: '#1A1A19' }}>{stat.value}</p>
+                <p className="text-[10px] mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>{stat.label}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Search ── */}
+      <div className="relative">
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
+          width="14" height="14" fill="none" stroke="rgba(26,26,25,0.3)" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+        </svg>
+        <input
+          type="text"
+          placeholder="Search by code, description, or unit…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="w-full pl-9 pr-4 py-2.5 rounded-xl text-sm outline-none transition-all duration-150"
+          style={{
+            background: 'white',
+            border: '1px solid rgba(133,159,61,0.18)',
+            color: '#1A1A19',
+            fontSize: '13px',
+          }}
+          onFocus={e => { e.currentTarget.style.borderColor = '#859F3D'; e.currentTarget.style.boxShadow = '0 0 0 3px rgba(133,159,61,0.1)'; }}
+          onBlur={e => { e.currentTarget.style.borderColor = 'rgba(133,159,61,0.18)'; e.currentTarget.style.boxShadow = 'none'; }}
+        />
+        {search && (
+          <button
+            onClick={() => setSearch('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2"
+            style={{ color: 'rgba(26,26,25,0.35)' }}
+          >
+            <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* ── Table ── */}
+      <div
+        className="rounded-2xl overflow-hidden"
+        style={{
+          background: 'white',
+          border: '1px solid rgba(133,159,61,0.1)',
+          boxShadow: '0 2px 12px rgba(26,26,25,0.05)',
+        }}
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr style={{ borderBottom: '1px solid rgba(133,159,61,0.1)' }}>
+                {[
+                  { label: 'Product Code', key: 'prodcode' },
+                  { label: 'Description',  key: 'description' },
+                  { label: 'Unit',         key: 'unit' },
+                  { label: 'Current Price',key: 'current_price' },
+                  { label: 'Effective Date',key: 'effective_date' },
+                ].map(col => (
+                  <th
+                    key={col.key}
+                    className="px-4 py-3 text-left cursor-pointer select-none"
+                    style={{ color: 'rgba(26,26,25,0.4)', fontSize: '10px', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase' }}
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    <SortIcon colKey={col.key} />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {loading
+                ? Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+                : filtered.length === 0
+                  ? <EmptyState search={search} />
+                  : filtered.map((row, idx) => (
+                    <tr
+                      key={row.prodcode}
+                      style={{
+                        borderBottom: idx < filtered.length - 1 ? '1px solid rgba(133,159,61,0.07)' : 'none',
+                        transition: 'background 0.12s',
+                      }}
+                      onMouseEnter={e => { e.currentTarget.style.background = 'rgba(133,159,61,0.03)'; }}
+                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+                    >
+                      {/* Product Code */}
+                      <td className="px-4 py-3.5">
+                        <span
+                          className="font-mono text-xs font-bold px-2 py-0.5 rounded-lg"
+                          style={{ background: 'rgba(133,159,61,0.08)', color: '#31511E' }}
+                        >
+                          {row.prodcode}
+                        </span>
+                      </td>
+
+                      {/* Description */}
+                      <td className="px-4 py-3.5">
+                        <span className="text-sm" style={{ color: '#1A1A19' }}>{row.description}</span>
+                      </td>
+
+                      {/* Unit */}
+                      <td className="px-4 py-3.5">
+                        <span
+                          className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-md"
+                          style={{ background: 'rgba(26,26,25,0.05)', color: 'rgba(26,26,25,0.5)' }}
+                        >
+                          {row.unit ?? '—'}
+                        </span>
+                      </td>
+
+                      {/* Price */}
+                      <td className="px-4 py-3.5">
+                        {row.current_price != null ? (
+                          <span className="text-sm font-bold" style={{ color: '#31511E' }}>
+                            {formatPrice(row.current_price)}
+                          </span>
+                        ) : (
+                          <span className="text-xs italic" style={{ color: 'rgba(26,26,25,0.3)' }}>No price</span>
+                        )}
+                      </td>
+
+                      {/* Effective Date */}
+                      <td className="px-4 py-3.5">
+                        <span className="text-xs" style={{ color: 'rgba(26,26,25,0.55)' }}>
+                          {formatDate(row.effective_date)}
+                        </span>
+                      </td>
+                    </tr>
+                  ))
+              }
+            </tbody>
+          </table>
+        </div>
+
+        {/* Footer */}
+        {!loading && filtered.length > 0 && (
+          <div
+            className="px-4 py-2.5 flex items-center justify-between"
+            style={{ borderTop: '1px solid rgba(133,159,61,0.08)' }}
+          >
+            <p className="text-[10px]" style={{ color: 'rgba(26,26,25,0.35)' }}>
+              {filtered.length} of {rows.length} product{rows.length !== 1 ? 's' : ''}
+              {search ? ` matching "${search}"` : ''}
+            </p>
+            <p className="text-[10px]" style={{ color: 'rgba(26,26,25,0.25)' }}>
+              Prices in PHP (₱)
+            </p>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/TopSellingPage.jsx
+++ b/src/pages/TopSellingPage.jsx
@@ -1,0 +1,455 @@
+// src/pages/TopSellingPage.jsx
+// REP_002 — Top Selling Products Report
+// Access: SUPERADMIN only (confidential executive/BI data)
+
+import { useState, useEffect } from 'react';
+import { useRights } from '../context/UserRightsContext';
+import { getTopSellingReport } from '../services/reportService';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const formatQty = (qty) =>
+  Number(qty).toLocaleString('en-PH');
+
+const getRankStyle = (rank) => {
+  if (rank === 1) return { bg: 'rgba(255,199,0,0.12)', color: '#92740a', border: '1px solid rgba(255,199,0,0.3)' };
+  if (rank === 2) return { bg: 'rgba(160,163,168,0.12)', color: '#5a5c61', border: '1px solid rgba(160,163,168,0.25)' };
+  if (rank === 3) return { bg: 'rgba(180,100,40,0.1)', color: '#7a4010', border: '1px solid rgba(180,100,40,0.2)' };
+  return { bg: 'rgba(133,159,61,0.07)', color: '#31511E', border: '1px solid rgba(133,159,61,0.12)' };
+};
+
+const RankMedal = ({ rank }) => {
+  if (rank === 1) return <span title="1st Place">🥇</span>;
+  if (rank === 2) return <span title="2nd Place">🥈</span>;
+  if (rank === 3) return <span title="3rd Place">🥉</span>;
+  return null;
+};
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+const SkeletonRow = () => (
+  <tr>
+    <td className="px-4 py-3.5">
+      <div className="w-7 h-5 rounded animate-pulse" style={{ background: 'rgba(133,159,61,0.1)' }} />
+    </td>
+    {[45, 18, 22].map((w, i) => (
+      <td key={i} className="px-4 py-3.5">
+        <div className="h-3 rounded-full animate-pulse" style={{ background: 'rgba(133,159,61,0.1)', width: `${w}%` }} />
+      </td>
+    ))}
+    <td className="px-4 py-3.5">
+      <div className="h-2.5 rounded-full animate-pulse" style={{ background: 'rgba(133,159,61,0.07)', width: '80%' }} />
+    </td>
+  </tr>
+);
+
+const EmptyState = () => (
+  <tr>
+    <td colSpan={5} className="px-4 py-16 text-center">
+      <div className="flex flex-col items-center gap-3">
+        <div className="w-12 h-12 rounded-2xl flex items-center justify-center"
+          style={{ background: 'rgba(133,159,61,0.08)' }}>
+          <svg width="22" height="22" fill="none" stroke="#859F3D" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+              d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+          </svg>
+        </div>
+        <div>
+          <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>No Sales Data</p>
+          <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.4)' }}>
+            No sales transactions found in the database.
+          </p>
+        </div>
+      </div>
+    </td>
+  </tr>
+);
+
+// ── Top Product Hero Card ──────────────────────────────────────────────────────
+
+const TopProductCard = ({ row, totalProducts }) => (
+  <div
+    className="relative overflow-hidden rounded-2xl px-6 py-5 flex flex-col sm:flex-row sm:items-center gap-5"
+    style={{
+      background: 'linear-gradient(135deg, #31511E 0%, #4a7a2e 60%, #859F3D 100%)',
+      boxShadow: '0 8px 32px rgba(49,81,30,0.25)',
+    }}
+  >
+    {/* Decorative background circles */}
+    <div
+      className="absolute top-0 right-0 w-48 h-48 rounded-full pointer-events-none"
+      style={{
+        background: 'rgba(255,255,255,0.04)',
+        transform: 'translate(30%, -30%)',
+      }}
+    />
+    <div
+      className="absolute bottom-0 right-24 w-32 h-32 rounded-full pointer-events-none"
+      style={{
+        background: 'rgba(255,255,255,0.03)',
+        transform: 'translateY(40%)',
+      }}
+    />
+
+    {/* Trophy icon */}
+    <div
+      className="w-16 h-16 rounded-2xl flex items-center justify-center text-3xl shrink-0"
+      style={{
+        background: 'rgba(255,199,0,0.15)',
+        border: '1px solid rgba(255,199,0,0.3)',
+        boxShadow: '0 4px 16px rgba(255,199,0,0.2)',
+      }}
+    >
+      🏆
+    </div>
+
+    {/* Info */}
+    <div className="flex-1 min-w-0 z-10">
+      <p
+        className="text-[9px] font-bold tracking-[0.25em] uppercase mb-1"
+        style={{ color: 'rgba(246,252,223,0.55)' }}
+      >
+        🥇 Top Selling Product
+      </p>
+      <p
+        className="text-xl font-bold truncate leading-tight"
+        style={{ color: '#F6FCDF' }}
+      >
+        {row.description}
+      </p>
+      <div className="flex items-center gap-3 mt-2 flex-wrap">
+        <span
+          className="font-mono text-[11px] font-bold px-2 py-0.5 rounded-lg"
+          style={{ background: 'rgba(246,252,223,0.12)', color: 'rgba(246,252,223,0.7)' }}
+        >
+          {row.prodcode}
+        </span>
+        <span
+          className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-md"
+          style={{ background: 'rgba(246,252,223,0.1)', color: 'rgba(246,252,223,0.6)' }}
+        >
+          {row.unit}
+        </span>
+      </div>
+    </div>
+
+    {/* Stats */}
+    <div
+      className="flex flex-row sm:flex-col items-center sm:items-end gap-4 sm:gap-1 z-10 shrink-0"
+    >
+      <div className="text-right">
+        <p
+          className="text-3xl font-black leading-none"
+          style={{ color: '#F6FCDF' }}
+        >
+          {formatQty(row.total_quantity_sold)}
+        </p>
+        <p
+          className="text-[10px] mt-0.5"
+          style={{ color: 'rgba(246,252,223,0.5)' }}
+        >
+          units sold
+        </p>
+      </div>
+      <div
+        className="text-[10px] font-semibold px-3 py-1 rounded-full"
+        style={{ background: 'rgba(246,252,223,0.12)', color: 'rgba(246,252,223,0.65)' }}
+      >
+        #1 of {totalProducts}
+      </div>
+    </div>
+  </div>
+);
+
+// ── Runner-up Cards (2nd and 3rd) ─────────────────────────────────────────────
+
+const RunnerUpCard = ({ row, medal, bgColor, borderColor, textColor }) => (
+  <div
+    className="flex items-center gap-3 px-4 py-3 rounded-xl flex-1"
+    style={{
+      background: bgColor,
+      border: `1px solid ${borderColor}`,
+    }}
+  >
+    <span className="text-xl shrink-0">{medal}</span>
+    <div className="flex-1 min-w-0">
+      <p className="text-xs font-bold truncate" style={{ color: '#1A1A19' }}>{row.description}</p>
+      <p className="font-mono text-[9px] mt-0.5" style={{ color: 'rgba(26,26,25,0.4)' }}>{row.prodcode}</p>
+    </div>
+    <div className="text-right shrink-0">
+      <p className="text-sm font-black" style={{ color: textColor }}>{formatQty(row.total_quantity_sold)}</p>
+      <p className="text-[9px]" style={{ color: 'rgba(26,26,25,0.35)' }}>units</p>
+    </div>
+  </div>
+);
+
+// ── Main Page ──────────────────────────────────────────────────────────────────
+
+export default function TopSellingPage() {
+  const { canViewRep002 } = useRights();
+
+  const [rows, setRows]       = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+
+  const maxQty = rows.length > 0 ? rows[0].total_quantity_sold : 1;
+
+  const fetchReport = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getTopSellingReport();
+      setRows(data);
+    } catch (err) {
+      console.error('TopSellingPage error:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (canViewRep002) fetchReport();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canViewRep002]);
+
+  // ── Access guard ──
+  if (!canViewRep002) {
+    return (
+      <div className="flex flex-col items-center justify-center h-72 gap-3">
+        <div
+          className="w-14 h-14 rounded-2xl flex items-center justify-center"
+          style={{ background: 'rgba(239,68,68,0.08)' }}
+        >
+          <svg width="24" height="24" fill="none" stroke="#dc2626" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+              d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+          </svg>
+        </div>
+        <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>Restricted Report</p>
+        <p className="text-xs text-center max-w-xs" style={{ color: 'rgba(26,26,25,0.45)' }}>
+          The Top Selling Products report is restricted to <strong>SUPERADMIN</strong> accounts only.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+
+      {/* ── Header ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>        
+          <h1 className="text-xl font-bold" style={{ color: '#1A1A19' }}>Top Selling Products</h1>
+          <p className="text-xs mt-0.5" style={{ color: 'rgba(26,26,25,0.45)' }}>
+            Top 10 products ranked by total quantity sold
+          </p>
+        </div>
+
+        <button
+          onClick={fetchReport}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-[11px] font-semibold transition-all duration-150 self-start sm:self-auto"
+          style={{ background: 'rgba(133,159,61,0.1)', color: '#31511E', opacity: loading ? 0.5 : 1 }}
+          onMouseEnter={e => { if (!loading) { e.currentTarget.style.background = '#31511E'; e.currentTarget.style.color = '#F6FCDF'; }}}
+          onMouseLeave={e => { if (!loading) { e.currentTarget.style.background = 'rgba(133,159,61,0.1)'; e.currentTarget.style.color = '#31511E'; }}}
+        >
+          <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }}>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+          </svg>
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+
+      {/* ── Error ── */}
+      {error && (
+        <div
+          className="px-4 py-3 rounded-xl text-xs"
+          style={{ background: 'rgba(239,68,68,0.08)', color: '#dc2626', border: '1px solid rgba(239,68,68,0.2)' }}
+        >
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      {/* ── Hero card skeleton ── */}
+      {loading && (
+        <div
+          className="rounded-2xl px-6 py-5 flex items-center gap-5 animate-pulse"
+          style={{ background: 'rgba(133,159,61,0.08)', minHeight: 100 }}
+        >
+          <div className="w-16 h-16 rounded-2xl" style={{ background: 'rgba(133,159,61,0.12)' }} />
+          <div className="flex-1 flex flex-col gap-2">
+            <div className="h-3 w-20 rounded-full" style={{ background: 'rgba(133,159,61,0.12)' }} />
+            <div className="h-5 w-48 rounded-full" style={{ background: 'rgba(133,159,61,0.12)' }} />
+            <div className="h-3 w-28 rounded-full" style={{ background: 'rgba(133,159,61,0.08)' }} />
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <div className="h-8 w-20 rounded-full" style={{ background: 'rgba(133,159,61,0.12)' }} />
+            <div className="h-3 w-16 rounded-full" style={{ background: 'rgba(133,159,61,0.08)' }} />
+          </div>
+        </div>
+      )}
+
+      {/* ── Top product hero + runner-ups ── */}
+      {!loading && rows.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {/* #1 Hero Card */}
+          <TopProductCard row={rows[0]} totalProducts={rows.length} />
+
+          {/* #2 and #3 runner-up cards */}
+          {rows.length > 1 && (
+            <div className="flex flex-col sm:flex-row gap-3">
+              {rows[1] && (
+                <RunnerUpCard
+                  row={rows[1]}
+                  medal="🥈"
+                  bgColor="rgba(160,163,168,0.07)"
+                  borderColor="rgba(160,163,168,0.2)"
+                  textColor="#5a5c61"
+                />
+              )}
+              {rows[2] && (
+                <RunnerUpCard
+                  row={rows[2]}
+                  medal="🥉"
+                  bgColor="rgba(180,100,40,0.06)"
+                  borderColor="rgba(180,100,40,0.15)"
+                  textColor="#7a4010"
+                />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Table ── */}
+      <div
+        className="rounded-2xl overflow-hidden"
+        style={{
+          background: 'white',
+          border: '1px solid rgba(133,159,61,0.1)',
+          boxShadow: '0 2px 12px rgba(26,26,25,0.05)',
+        }}
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr style={{ borderBottom: '1px solid rgba(133,159,61,0.1)' }}>
+                {['Rank', 'Product', 'Unit', 'Total Qty Sold', 'Volume Bar'].map(label => (
+                  <th
+                    key={label}
+                    className="px-4 py-3 text-left"
+                    style={{ color: 'rgba(26,26,25,0.4)', fontSize: '10px', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase' }}
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {loading
+                ? Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+                : rows.length === 0
+                  ? <EmptyState />
+                  : rows.map((row, idx) => {
+                    const rankStyle = getRankStyle(row.rank);
+                    const pct = maxQty > 0 ? (row.total_quantity_sold / maxQty) * 100 : 0;
+                    return (
+                      <tr
+                        key={row.prodcode}
+                        style={{
+                          borderBottom: idx < rows.length - 1 ? '1px solid rgba(133,159,61,0.07)' : 'none',
+                          transition: 'background 0.12s',
+                        }}
+                        onMouseEnter={e => { e.currentTarget.style.background = 'rgba(133,159,61,0.03)'; }}
+                        onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+                      >
+                        {/* Rank */}
+                        <td className="px-4 py-3.5">
+                          <div className="flex items-center gap-1.5">
+                            <span
+                              className="inline-flex items-center justify-center w-7 h-5 rounded-md text-[11px] font-bold"
+                              style={{ background: rankStyle.bg, color: rankStyle.color, border: rankStyle.border }}
+                            >
+                              #{row.rank}
+                            </span>
+                            <RankMedal rank={row.rank} />
+                          </div>
+                        </td>
+
+                        {/* Product */}
+                        <td className="px-4 py-3.5">
+                          <div>
+                            <p className="text-sm font-semibold" style={{ color: '#1A1A19' }}>{row.description}</p>
+                            <p className="font-mono text-[10px] mt-0.5" style={{ color: 'rgba(26,26,25,0.4)' }}>
+                              {row.prodcode}
+                            </p>
+                          </div>
+                        </td>
+
+                        {/* Unit */}
+                        <td className="px-4 py-3.5">
+                          <span
+                            className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-md"
+                            style={{ background: 'rgba(26,26,25,0.05)', color: 'rgba(26,26,25,0.5)' }}
+                          >
+                            {row.unit ?? '—'}
+                          </span>
+                        </td>
+
+                        {/* Qty */}
+                        <td className="px-4 py-3.5">
+                          <span className="text-sm font-bold" style={{ color: '#31511E' }}>
+                            {formatQty(row.total_quantity_sold)}
+                          </span>
+                        </td>
+
+                        {/* Bar */}
+                        <td className="px-4 py-3.5" style={{ minWidth: 120 }}>
+                          <div className="relative h-2 rounded-full overflow-hidden"
+                            style={{ background: 'rgba(133,159,61,0.1)' }}>
+                            <div
+                              className="absolute inset-y-0 left-0 rounded-full transition-all duration-500"
+                              style={{
+                                width: `${pct}%`,
+                                background: row.rank === 1
+                                  ? 'linear-gradient(90deg, #31511E, #859F3D)'
+                                  : '#859F3D',
+                                opacity: row.rank <= 3 ? 1 : 0.6,
+                              }}
+                            />
+                          </div>
+                          <p className="text-[9px] mt-0.5" style={{ color: 'rgba(26,26,25,0.3)' }}>
+                            {pct.toFixed(0)}% of top
+                          </p>
+                        </td>
+                      </tr>
+                    );
+                  })
+              }
+            </tbody>
+          </table>
+        </div>
+
+        {/* Footer */}
+        {!loading && rows.length > 0 && (
+          <div
+            className="px-4 py-2.5"
+            style={{ borderTop: '1px solid rgba(133,159,61,0.08)' }}
+          >
+            <p className="text-[10px]" style={{ color: 'rgba(26,26,25,0.35)' }}>
+              Showing top {rows.length} products by total quantity sold across all transactions
+            </p>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+      `}</style>
+    </div>
+  );
+}

--- a/src/services/reportService.js
+++ b/src/services/reportService.js
@@ -48,8 +48,11 @@ export async function getProductPriceReport() {
  REP_002 — Top-Selling Products Report
  Access: SUPERADMIN only (confidential executive/BI data)
  
- Returns the top 10 products ranked by total quantity sold across
+ Returns the top 10 ACTIVE products ranked by total quantity sold across
  all sales transactions, joining salesdetail → product.
+ 
+ Only ACTIVE products are included — deactivated products are excluded
+ from the ranking even if they have historical sales data.
  **/
 export async function getTopSellingReport() {
   const { data, error } = await supabase
@@ -57,11 +60,13 @@ export async function getTopSellingReport() {
     .select(`
       prodcode,
       quantity,
-      product (
+      product!inner (
         description,
-        unit
+        unit,
+        record_status
       )
-    `);
+    `)
+    .eq('product.record_status', 'ACTIVE'); // ← only include ACTIVE products
 
   if (error) throw error;
 


### PR DESCRIPTION

feat/ui-reports — ProductReportPage (REP_001) + TopSellingPage (REP_002)
**What Changed**
Built both report pages for Sprint 3. REP_001 is accessible to all authenticated roles with CSV export, REP_002 is SUPERADMIN only with confidential data banner and redesigned top product hero card. Fixed REP_002 to exclude deactivated products from the ranking.
**Files Changed**

src/pages/ProductReportPage.jsx → new file
src/pages/TopSellingPage.jsx → new file
src/services/reportService.js → updated getTopSellingReport() to filter ACTIVE products only
src/App.jsx → added /reports/product-listing and /reports/top-selling routes

**Components Added**
ProductReportPage (REP_001) — Shows all ACTIVE products with current price and effective date:

**REP-001 badge + page header**
Stats bar — Active Products / With Price / No Price Set counts
Sortable columns (click header to toggle asc/desc) with visual sort arrows
Live search filter by product code, description, or unit with clear X button
Prices formatted as ₱1,234.00 (PHP locale), dates as readable format
Skeleton loading rows while fetching
Empty state for no results (with and without search query)
Refresh button with spinning icon while loading
Row hover highlights
CSV Export button — exports current filtered/sorted view as product_report_YYYY-MM-DD.csv per project guide Sprint 3. Only visible when data is loaded. Columns: Product Code, Description, Unit, Current Price, Effective Date
Access guard — shows Access Denied screen if canViewRep001 is false
Calls getProductPriceReport() from reportService.js

**TopSellingPage (REP_002) — Shows top 10 ACTIVE products ranked by total quantity sold:**

**REP-002 badge + Superadmin Only badge in header**
Confidential data banner (red, subtle)
Hero card — full dark green gradient showing #1 product with trophy icon, product name, code badge, unit badge, large bold unit count, and "#1 of N" rank context badge. Decorative background circles for depth
Runner-up cards — silver-tinted (#2) and bronze-tinted (#3) shown side by side below hero
Rank badges — gold/silver/bronze for top 3, green for the rest with medal emojis (🥇🥈🥉)
Horizontal volume bar showing each product's share relative to #1
Hero card animated skeleton while loading
Empty state when no sales data found
Refresh button with spinning icon while loading
Access guard — shows Restricted Report screen if canViewRep002 is false
Calls getTopSellingReport() from reportService.js

reportService.js Changes
getTopSellingReport() — fixed to only include ACTIVE products:

Changed product to product!inner — uses INNER JOIN so salesdetail rows with no matching product are excluded entirely
Added .eq('product.record_status', 'ACTIVE') filter — deactivated products are excluded from the ranking even if they have historical sales data
This matches the same behavior as getProductPriceReport() which already filtered by record_status = ACTIVE
Practical effect: if a product is soft-deleted/deactivated, it immediately drops out of the Top 10 ranking on next refresh

**Route Changes**

/reports/product-listing → ProductReportPage wrapped in ProtectedRoute
/reports/top-selling → TopSellingPage wrapped in ProtectedRoute (page self-guards via canViewRep002)
Sidebar already had correct to paths — no Sidebar changes needed

**Access Control (§2.2)**

REP_001 — all authenticated roles (SUPERADMIN, ADMIN, USER) via canViewRep001
REP_002 — SUPERADMIN only via canViewRep002
Both routes wrapped in ProtectedRoute — unauthenticated users redirected to /login
Page-level guards show friendly Access Denied / Restricted screens instead of blank pages

**Notes**

Both pages call existing reportService.js functions — no direct Supabase calls in page files
REP_002 shows confidential banner per project guide — executive/BI data
CSV export exports current filtered view — search filter is respected on export
Price exported as raw number (e.g. 1234.50) for spreadsheet compatibility
reportService.js fix should be review